### PR TITLE
Handle LeagueEntry for RANKED_TFT_TURBO type

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
@@ -310,15 +310,11 @@ public enum GameQueueType implements CodedEnum
     /**
      * Teamfight Tactics (Hyper roll)
      */
-    TEAMFIGHT_TACTICS_HYPER_ROLL(new Integer[]{1130}),
+    TEAMFIGHT_TACTICS_HYPER_ROLL(new Integer[]{1130}, "RANKED_TFT_TURBO"),
     /**
      * Teamfight Tactics (Hyper roll) (1v0)
      */
     TEAMFIGHT_TACTICS_HYPER_ROLL_1V0(new Integer[]{1131}),
-    /**
-     * Teamfight Tactics (Hyper roll Set 5)
-     */
-    TEAMFIGHT_TACTICS_TURBO(new Integer[]{1100}, "RANKED_TFT_TURBO"),
     /**
      * Ultimate Spellbook
      */

--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
@@ -316,6 +316,10 @@ public enum GameQueueType implements CodedEnum
      */
     TEAMFIGHT_TACTICS_HYPER_ROLL_1V0(new Integer[]{1131}),
     /**
+     * Teamfight Tactics (Hyper roll Set 5)
+     */
+    TEAMFIGHT_TACTICS_TURBO(new Integer[]{1100}, "RANKED_TFT_TURBO"),
+    /**
      * Ultimate Spellbook
      */
     ULTBOOK(new Integer[]{1400}),

--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/RatedTier.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/RatedTier.java
@@ -1,0 +1,27 @@
+package no.stelar7.api.r4j.basic.constants.types.lol;
+
+public enum RatedTier {
+  ORANGE("ORANGE"),
+  PURPLE("PURPLE"),
+  BLUE("BLUE"), 
+  GREEN("GREEN"),
+  GRAY("GRAY");
+
+  private String apiName;
+
+  private RatedTier(String apiName) {
+    this.apiName = apiName;
+  }
+
+  public static RatedTier getRatedTierWithApiName(String ratedTier) {
+    for(RatedTier tierToCheck : RatedTier.values()) {
+      if(ratedTier.equals(tierToCheck.getApiName()))
+        return tierToCheck;
+    }
+    return null;
+  }
+
+  public String getApiName() {
+    return apiName;
+  }
+}

--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/RatedTier.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/RatedTier.java
@@ -9,11 +9,13 @@ public enum RatedTier {
 
   private String apiName;
 
-  private RatedTier(String apiName) {
+  private RatedTier(String apiName) 
+  {
     this.apiName = apiName;
   }
 
-  public static RatedTier getRatedTierWithApiName(String ratedTier) {
+  public static RatedTier getRatedTierWithApiName(String ratedTier) 
+  {
     for(RatedTier tierToCheck : RatedTier.values()) {
       if(ratedTier.equals(tierToCheck.getApiName()))
         return tierToCheck;
@@ -21,7 +23,8 @@ public enum RatedTier {
     return null;
   }
 
-  public String getApiName() {
+  public String getApiName() 
+  {
     return apiName;
   }
 }

--- a/src/main/java/no/stelar7/api/r4j/pojo/lol/league/LeagueEntry.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/lol/league/LeagueEntry.java
@@ -12,6 +12,8 @@ public class LeagueEntry extends LeagueItem implements Serializable
     private GameQueueType queueType;
     private String        tier;
     private String        leagueId;
+    private String        ratedTier;
+    private Integer       ratedRating;
     
     public GameQueueType getQueueType()
     {
@@ -31,6 +33,16 @@ public class LeagueEntry extends LeagueItem implements Serializable
     public String getLeagueId()
     {
         return leagueId;
+    }
+    
+    public RatedTier getRatedTier()
+    {
+      return RatedTier.getRatedTierWithApiName(ratedTier);
+    }
+    
+    public int getRatedRating() 
+    {
+      return ratedRating;
     }
     
     @Override
@@ -78,6 +90,8 @@ public class LeagueEntry extends LeagueItem implements Serializable
                ", inactive=" + inactive +
                ", freshBlood=" + freshBlood +
                ", leaguePoints=" + leaguePoints +
+               ", ratedTier=" + ratedTier +
+               ", ratedRating=" + ratedRating +
                '}';
     }
 }

--- a/src/test/java/no/stelar7/api/r4j/tests/tft/TestTFTLeague.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/tft/TestTFTLeague.java
@@ -34,7 +34,7 @@ public class TestTFTLeague
     @Test
     public void testEntries()
     {
-        List<LeagueEntry> entries = l4j8.getTFTAPI().getLeagueAPI().getLeagueEntries(LeagueShard.EUW1, Summoner.byName(LeagueShard.EUW1, "stelar7").getSummonerId());
+        List<LeagueEntry> entries = l4j8.getTFTAPI().getLeagueAPI().getLeagueEntries(LeagueShard.EUW1, Summoner.byName(LeagueShard.EUW1, "Rogu chan").getSummonerId());
         System.out.println();
     }
     


### PR DESCRIPTION
Hello!

This PR allows to manage the LeagueEntry type "RANKED_TFT_TURBO". The appropriate fields have been added.

I have no idea if this implementation is suitable for you, I'll let you see.
But you should know that it is functional (tested with the Summoner "Rogu chan" which was causing me problems)

Have a great day!