### PR TITLE
Fix ranked data access for Classic TFT ranked

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/pojo/tft/league/TFTLeagueEntry.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/tft/league/TFTLeagueEntry.java
@@ -13,18 +13,6 @@ public class TFTLeagueEntry extends LeagueEntry implements Serializable
     private TFTTier ratedTier;
     private int     ratedRating;
     
-    @Override
-    public String getTier()
-    {
-        return ratedTier.name();
-    }
-    
-    @Override
-    public int getLeaguePoints()
-    {
-        return ratedRating;
-    }
-    
     public TFTTier getRatedTier()
     {
         return ratedTier;


### PR DESCRIPTION
Hey again!

Your update is great, thanks you for it. It's looks better now. However i found a small issue inside your push:

There's two types of ranked mode for TFT: 
  - Hyper Roll mode (which use ratedRating and ratedTier)
  - Classic Ranked mode (which use classic ranked data)

Since we want to have access to classic ranked data for the second case, we have to delete the override of the `TFTLeagueEntry#getTier` method which hide the `LeagueEntry#getTier` method behind it (so we can have access to needed data). Api description [here](https://developer.riotgames.com/apis#tft-league-v1/GET_getLeagueEntriesForSummoner).

We can't really make a better design here in my opinion since the base design of the api is already clunky.

With this change everything should be good. Thanks again!