### PR TITLE
Add 'One For All' Queue Id (Valorant)

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/val/GameQueueType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/val/GameQueueType.java
@@ -14,6 +14,7 @@ public enum GameQueueType implements CodedEnum<GameQueueType>
     UNRATED("unrated"),
     CUSTOM_GAME(""),
     TOURNAMENT_MODE("tournamentmode"),
+    ONE_FOR_ALL("onefa"),
     ;
     
     


### PR DESCRIPTION
Caused by: no.stelar7.api.r4j.basic.exceptions.APIEnumNotUpToDateException: The enum no.stelar7.api.r4j.basic.constants.types.val.GameQueueType is missing the type "onefa"!
Please make sure you have the latest version of the library!
If you do, send this message to the maintainer of the API.