### PR TITLE
Bug fix: Remove invalid/bugged entry from DDragon Items Endpoint

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -288,7 +288,6 @@ public class DataCallBuilder
     
     private String postProcessDDragonAddId(String returnValue)
     {
-        List<String> buggedElem = new ArrayList<>();
         JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
         JsonObject parent = elem.getAsJsonObject("data");
         for (String key : new HashSet<>(parent.keySet()))
@@ -301,14 +300,9 @@ public class DataCallBuilder
                 
             }   catch(NumberFormatException e) 
             {
-                buggedElem.add(key);
-                logger.warn("Item received without a valid Id ({}), item removed from the list", key);
+                parent.remove(key);
+                logger.warn("Item/Rune received without a valid Id ({}), item removed from the list", key);
             }
-        }
-        
-        for(String elemToRemove : buggedElem) 
-        {
-            elem.getAsJsonObject("data").remove(elemToRemove);
         }
         
         return Utils.getGson().toJson(elem);

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -288,12 +288,27 @@ public class DataCallBuilder
     
     private String postProcessDDragonAddId(String returnValue)
     {
+        List<String> buggedElem = new ArrayList<>();
         JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
         JsonObject parent = elem.getAsJsonObject("data");
         for (String key : new HashSet<>(parent.keySet()))
         {
             JsonObject child = parent.getAsJsonObject(key);
-            child.addProperty("id", key);
+            try 
+            {
+                int keyAsInt = Integer.parseInt(key);
+                child.addProperty("id", keyAsInt);
+                
+            }   catch(NumberFormatException e) 
+            {
+                buggedElem.add(key);
+                logger.warn("Item received without a valid Id ({}), item removed from the list", key);
+            }
+        }
+        
+        for(String elemToRemove : buggedElem) 
+        {
+            elem.getAsJsonObject("data").remove(elemToRemove);
         }
         
         return Utils.getGson().toJson(elem);


### PR DESCRIPTION
A new "buggy" object seems to have appeared in DDragon. When I say buggy, I mean that its name is a String (TalentReaperItem) and not a number like all the other items and that its image suggests that it is a weird version of the support item "Steel Shoulderguards".

R4J doesn't handle strings as id for items and therefore crashes. Here is a fix to solve the problem. (If the id is not a number -> the object is deleted).