### PR TITLE
Fix Arena game mode (TeamType error) + Add field to determine team in Arena game mode.

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/TeamType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/TeamType.java
@@ -1,15 +1,38 @@
 package no.stelar7.api.r4j.basic.constants.types.lol;
 
 import no.stelar7.api.r4j.basic.constants.types.CodedEnum;
+import no.stelar7.api.r4j.pojo.lol.match.v5.MatchParticipant;
 
 import java.util.*;
 import java.util.stream.*;
 
+/**
+ * Represent in which team a player is in Classical League game mode (Summoner's Rift, ARAM, ...). <br><br>
+ * 
+ * <b>IMPORTANT NOTE: Teams in Arena game mode (Cherry) are not determined by {@link TeamType} 
+ * but by the "playerSubteamId" field inside {@link MatchParticipant#getArenaTeamId()}. </b> 
+ * The meaning of this field for Arena Game Mode remain unknown. <br><br>
+ * 
+ * (Please update this if you have find a meaning to it)
+ */
 public enum TeamType implements CodedEnum
 {
-    
+	/**
+	 * Team 0 appearing in Arena game type. <br>
+	 * <b>DOES NOT REPRESENT A TEAM, PLEASE SEE "playerSubteamId" field in {@link MatchParticipant#getArenaTeamId()} !</b>
+	 */
+    TEAM0(0),
+    /**
+     * Blue Team OR Team 1 in Arena game type
+     */
     BLUE(100),
+    /**
+     * Red Team OR Team 2 in Arena game type
+     */
     RED(200),
+    /**
+     * AI Team
+     */
     AI(300);
     
     private final Integer code;

--- a/src/main/java/no/stelar7/api/r4j/pojo/lol/match/v5/MatchParticipant.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/lol/match/v5/MatchParticipant.java
@@ -116,6 +116,10 @@ public class MatchParticipant implements Serializable
     private int                 wardsPlaced;
     private boolean             win;
     
+    //Arena Game Mode field
+    
+    private int playerSubteamId;
+    
     public int getAssists()
     {
         return assists;
@@ -641,7 +645,15 @@ public class MatchParticipant implements Serializable
         return win;
     }
     
-    public Map<String, Object> getChallenges()
+    /**
+     * Used to determine team in Arena Game Mode
+     * @return team id. Can be 1-4. Return 0 if the game mode is not arena (cherry).
+     */
+    public int getArenaTeamId() {
+		return playerSubteamId;
+	}
+
+	public Map<String, Object> getChallenges()
     {
         return challenges;
     }

--- a/src/test/java/no/stelar7/api/r4j/tests/lol/match/MatchListV5Test.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/lol/match/MatchListV5Test.java
@@ -2,6 +2,8 @@ package no.stelar7.api.r4j.tests.lol.match;
 
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonWriter;
+
+import no.stelar7.api.r4j.basic.APICredentials;
 import no.stelar7.api.r4j.basic.cache.impl.FileSystemCacheProvider;
 import no.stelar7.api.r4j.basic.calling.DataCall;
 import no.stelar7.api.r4j.basic.constants.api.regions.LeagueShard;
@@ -16,6 +18,8 @@ import no.stelar7.api.r4j.pojo.lol.summoner.Summoner;
 import no.stelar7.api.r4j.tests.SecretFile;
 import org.junit.jupiter.api.*;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
@@ -24,7 +28,6 @@ import java.util.*;
 public class MatchListV5Test
 {
     final R4J r4J = new R4J(SecretFile.CREDS);
-    
     
     @Test
     @Disabled
@@ -146,6 +149,7 @@ public class MatchListV5Test
     }
     
     @Test
+    @Disabled
     public void testMatchBadDuration()
     {
         LOLMatch match = LOLMatch.get(LeagueShard.BR1, "BR1_2344333561");
@@ -168,6 +172,34 @@ public class MatchListV5Test
                 lolMatch.getTimeline();
             }
         }
+    }
+    
+    @Test
+    @Disabled
+    public void testCherryGameMode()
+    {
+    	LOLMatch match = LOLMatch.get(LeagueShard.EUW1, "EUW1_6507642888");
+        System.out.println(); //We check that this test does not crash
+    }
+    
+    @Test
+    @Disabled
+    public void testCherryGameModeTeamId()
+    {
+    	LOLMatch match = LOLMatch.get(LeagueShard.EUW1, "EUW1_6507642888");
+    	if(match.getParticipants().get(0).getArenaTeamId() == 0) {
+    		fail("The given game is a Arena game, player must have arena team id.");
+    	}
+    }
+    
+    @Test
+    @Disabled
+    public void testClassicalGameDoesNotHaveArenaTeamId()
+    {
+    	LOLMatch match = LOLMatch.get(LeagueShard.EUW1, "EUW1_6503326297");
+    	if(match.getParticipants().get(0).getArenaTeamId() != 0) {
+    		fail("The given game is a Normal Draft, player should not have an arena team id.");
+    	}
     }
 }
 


### PR DESCRIPTION
This commit should avoid any error. The Riot api return for some players a "TeamType" of 0 which would create a crash of the parsing process.

The weird thing is that the TeamType field seems to have no meaning since player team are determined in new field called "playerSubteamId".

A lot of work still need to be done to fully support Arena game mode. A lot of new fields have been added specifically for this game type.