### PR TITLE
Allow to select which api key to use RiotAccountEndpoint

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/api/ApiKey.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/api/ApiKey.java
@@ -1,0 +1,9 @@
+package no.stelar7.api.r4j.basic.constants.api;
+
+public enum ApiKey {
+  LOL,
+  TOURNAMENT,
+  TFT,
+  VAL,
+  LOR
+}

--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
@@ -342,6 +342,8 @@ public enum GameQueueType implements CodedEnum
     
     TEAMFIGHT_TACTICS_SOUL_BRAWL(new Integer[]{1180}),
     
+    TEAMFIGHT_TACTICS_CHONCC_TREASURE(new Integer[]{1190}),
+    
     /**
      * 2v2v2v2
      */

--- a/src/main/java/no/stelar7/api/r4j/basic/utils/Utils.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/utils/Utils.java
@@ -1,6 +1,9 @@
 package no.stelar7.api.r4j.basic.utils;
 
 import com.google.gson.*;
+
+import no.stelar7.api.r4j.basic.calling.DataCall;
+import no.stelar7.api.r4j.basic.constants.api.ApiKey;
 import no.stelar7.api.r4j.basic.constants.api.regions.*;
 import no.stelar7.api.r4j.basic.constants.types.lol.*;
 import no.stelar7.api.r4j.basic.constants.types.tft.TFTTier;
@@ -82,6 +85,29 @@ public final class Utils
         builder.registerTypeAdapter(no.stelar7.api.r4j.basic.constants.types.val.Skill.class, new GenericEnumSerializer<no.stelar7.api.r4j.basic.constants.types.val.Skill>());
         
         gson = builder.setPrettyPrinting().disableHtmlEscaping().create();
+    }
+    
+    public static String getSelectedApiKey(ApiKey keySelection) 
+    {
+        String key = null;
+        switch (keySelection) {
+        case LOL:
+          key = DataCall.getCredentials().getLoLAPIKey();
+          break;
+        case LOR:
+          key = DataCall.getCredentials().getLORAPIKey();
+          break;
+        case TFT:
+          key = DataCall.getCredentials().getTFTAPIKey();
+          break;
+        case TOURNAMENT:
+          key = DataCall.getCredentials().getTournamentAPIKey();
+          break;
+        case VAL:
+          key = DataCall.getCredentials().getVALAPIKey();
+          break;
+        }
+        return key;
     }
     
     public static String padLeft(String input, String val, int length)

--- a/src/main/java/no/stelar7/api/r4j/impl/shared/AccountAPI.java
+++ b/src/main/java/no/stelar7/api/r4j/impl/shared/AccountAPI.java
@@ -25,8 +25,14 @@ public class AccountAPI
     
     public RiotAccount getAccountByPUUID(RegionShard server, String puuid)
     {
+        return getAccountByPUUID(server, puuid, ApiKey.VAL);
+    }
+    
+    public RiotAccount getAccountByPUUID(RegionShard server, String puuid, ApiKey keySelected)
+    {   
+        
         DataCallBuilder builder = new DataCallBuilder().withURLParameter(Constants.PUUID_ID_PLACEHOLDER, puuid)
-                                                       .withHeader(Constants.X_RIOT_TOKEN_HEADER_KEY, DataCall.getCredentials().getVALAPIKey())
+                                                       .withHeader(Constants.X_RIOT_TOKEN_HEADER_KEY, Utils.getSelectedApiKey(keySelected))
                                                        .withEndpoint(URLEndpoint.V1_SHARED_ACCOUNT_BY_PUUID)
                                                        .withPlatform(server);
         Map<String, Object> data = new LinkedHashMap<>();
@@ -55,9 +61,14 @@ public class AccountAPI
     
     public RiotAccount getAccountByTag(RegionShard server, String name, String tag)
     {
+        return getAccountByTag(server, name, tag, ApiKey.VAL);
+    }
+    
+    public RiotAccount getAccountByTag(RegionShard server, String name, String tag, ApiKey keySelected)
+    {
         DataCallBuilder builder = new DataCallBuilder().withURLParameter(Constants.GAME_NAME_PLACEHOLDER, Utils.normalizeString(name))
                                                        .withURLParameter(Constants.TAG_LINE_PLACEHOLDER, Utils.normalizeString(tag))
-                                                       .withHeader(Constants.X_RIOT_TOKEN_HEADER_KEY, DataCall.getCredentials().getVALAPIKey())
+                                                       .withHeader(Constants.X_RIOT_TOKEN_HEADER_KEY, Utils.getSelectedApiKey(keySelected))
                                                        .withEndpoint(URLEndpoint.V1_SHARED_ACCOUNT_BY_TAG)
                                                        .withPlatform(server);
         Map<String, Object> data = new LinkedHashMap<>();
@@ -87,9 +98,14 @@ public class AccountAPI
     
     public RiotAccountShard getActiveShard(RegionShard server, ShardableGame game, String puuid)
     {
+        return getActiveShard(server, game, puuid, ApiKey.VAL);
+    }
+    
+    public RiotAccountShard getActiveShard(RegionShard server, ShardableGame game, String puuid, ApiKey keySelected)
+    {
         DataCallBuilder builder = new DataCallBuilder().withURLParameter(Constants.GAME_PLACEHOLDER, game.getRealmValue())
                                                        .withURLParameter(Constants.PUUID_ID_PLACEHOLDER, puuid)
-                                                       .withHeader(Constants.X_RIOT_TOKEN_HEADER_KEY, DataCall.getCredentials().getVALAPIKey())
+                                                       .withHeader(Constants.X_RIOT_TOKEN_HEADER_KEY, Utils.getSelectedApiKey(keySelected))
                                                        .withEndpoint(URLEndpoint.V1_SHARED_SHARD_BY_PUUID)
                                                        .withPlatform(server);
         Map<String, Object> data = new LinkedHashMap<>();


### PR DESCRIPTION
I've added the ability to choose which API key is used for calls to RiotAccount endpoints. For applications that support multiple games, this is critical as the PUUID must be obtained for each key, since responses are encrypted.

This update is transparent to the end user. The default behavior has not changed.