### PR TITLE
Add new Champion Mastery endpoint (PUUID version)

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/api/URLEndpoint.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/api/URLEndpoint.java
@@ -56,6 +56,14 @@ public enum URLEndpoint
     V4_MASTERY_BY_CHAMPION("lol", "champion-mastery", "v4", "champion-masteries/by-summoner/" + Constants.SUMMONER_ID_PLACEHOLDER + "/by-champion/" + Constants.CHAMPION_ID_PLACEHOLDER, ChampionMastery.class),
     V4_MASTERY_SCORE("lol", "champion-mastery", "v4", "scores/by-summoner/" + Constants.SUMMONER_ID_PLACEHOLDER, Integer.class),
     
+    // lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}
+    // lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}/by-champion/{championId}
+    // lol/champion-mastery/v4/scores/by-summoner/{summonerId}
+    V4_MASTERY_PUUID_BY_ID("lol", "champion-mastery", "v4", "champion-masteries/by-puuid/" + Constants.PUUID_ID_PLACEHOLDER, ChampionMasteryList.class),
+    V4_MASTERY_PUUID_BY_CHAMPION("lol", "champion-mastery", "v4", "champion-masteries/by-puuid/" + Constants.PUUID_ID_PLACEHOLDER + "/by-champion/" + Constants.CHAMPION_ID_PLACEHOLDER, ChampionMastery.class),
+    V4_MASTERY_PUUID_SCORE("lol", "champion-mastery", "v4", "scores/by-puuid/" + Constants.PUUID_ID_PLACEHOLDER, Integer.class),
+    
+    
     // lol/platform/v3/champion-rotations
     V3_CHAMPION_ROTATIONS("lol", "platform", "v3", "champion-rotations", ChampionRotationInfo.class),
     

--- a/src/main/java/no/stelar7/api/r4j/impl/lol/builders/championmastery/ChampionMasteryBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/impl/lol/builders/championmastery/ChampionMasteryBuilder.java
@@ -63,20 +63,35 @@ public class ChampionMasteryBuilder
     
     public Integer getMasteryScore()
     {
-        if (this.summonerId == null || this.platform == LeagueShard.UNKNOWN)
+        if (!(this.summonerId != null || this.puuid != null) || this.platform == LeagueShard.UNKNOWN)
         {
             return null;
         }
         
         
-        DataCallBuilder builder = new DataCallBuilder().withURLParameter(Constants.SUMMONER_ID_PLACEHOLDER, this.summonerId)
-                                                       .withEndpoint(URLEndpoint.V4_MASTERY_SCORE)
-                                                       .withPlatform(this.platform);
+        DataCallBuilder builder = new DataCallBuilder().withPlatform(this.platform);
+        
+        URLEndpoint endpoint;
+        String id;
+        String idPlaceHolder;
+        if(this.puuid != null)
+        {
+          id = this.puuid;
+          endpoint = URLEndpoint.V4_MASTERY_PUUID_SCORE;
+          idPlaceHolder = Constants.PUUID_ID_PLACEHOLDER;
+        } 
+        else 
+        {
+          id = this.summonerId;
+          endpoint = URLEndpoint.V4_MASTERY_SCORE;
+          idPlaceHolder = Constants.SUMMONER_ID_PLACEHOLDER;
+        }
+        
+        builder = builder.withURLParameter(idPlaceHolder, id).withEndpoint(endpoint);
         
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("platform", this.platform);
-        data.put("id", summonerId);
-        
+        data.put("id", id);
         
         Optional<?> chl = DataCall.getCacheProvider().get(URLEndpoint.V4_MASTERY_SCORE, data);
         if (chl.isPresent())
@@ -100,26 +115,34 @@ public class ChampionMasteryBuilder
     
     public List<ChampionMastery> getChampionMasteries()
     {
-        if (this.summonerId == null || this.platform == LeagueShard.UNKNOWN)
+        if (!(this.summonerId != null || this.puuid != null) || this.platform == LeagueShard.UNKNOWN)
         {
             return Collections.emptyList();
         }
         
-        DataCallBuilder builder = new DataCallBuilder().withEndpoint(URLEndpoint.V4_MASTERY_BY_ID)
-                                                       .withPlatform(this.platform);
+        DataCallBuilder builder = new DataCallBuilder().withPlatform(this.platform);
         
+        URLEndpoint endpoint;
+        String id;
+        String idPlaceHolder;
         if(this.puuid != null)
         {
-          builder = builder.withURLParameter(Constants.PUUID_ID_PLACEHOLDER, this.puuid);
-        }
-        else
+          id = this.puuid;
+          endpoint = URLEndpoint.V4_MASTERY_PUUID_BY_ID;
+          idPlaceHolder = Constants.PUUID_ID_PLACEHOLDER;
+        } 
+        else 
         {
-          builder = builder.withURLParameter(Constants.SUMMONER_ID_PLACEHOLDER, this.summonerId);
+          id = this.summonerId;
+          endpoint = URLEndpoint.V4_MASTERY_BY_ID;
+          idPlaceHolder = Constants.SUMMONER_ID_PLACEHOLDER;
         }
+        
+        builder = builder.withURLParameter(idPlaceHolder, id).withEndpoint(endpoint);
         
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("platform", platform);
-        data.put("id", summonerId);
+        data.put("id", id);
         
         Optional<?> chl = DataCall.getCacheProvider().get(URLEndpoint.V4_MASTERY_BY_ID, data);
         if (chl.isPresent())
@@ -166,27 +189,30 @@ public class ChampionMasteryBuilder
         }
         
         DataCallBuilder builder = new DataCallBuilder().withURLParameter(Constants.CHAMPION_ID_PLACEHOLDER, String.valueOf(this.championId))
-                                                       .withEndpoint(URLEndpoint.V4_MASTERY_BY_CHAMPION)
                                                        .withPlatform(this.platform);
         
-        
+        URLEndpoint endpoint;
         String id;
+        String idPlaceHolder;
         if(this.puuid != null)
         {
-          builder = builder.withURLParameter(Constants.PUUID_ID_PLACEHOLDER, this.puuid);
           id = this.puuid;
+          endpoint = URLEndpoint.V4_MASTERY_PUUID_BY_CHAMPION;
+          idPlaceHolder = Constants.PUUID_ID_PLACEHOLDER;
         } 
         else 
         {
-          builder = builder.withURLParameter(Constants.SUMMONER_ID_PLACEHOLDER, this.summonerId);
           id = this.summonerId;
+          endpoint = URLEndpoint.V4_MASTERY_BY_CHAMPION;
+          idPlaceHolder = Constants.SUMMONER_ID_PLACEHOLDER;
         }
+        
+        builder = builder.withURLParameter(idPlaceHolder, id).withEndpoint(endpoint);
         
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("platform", platform);
         data.put("id", id);
         data.put("champion", championId);
-        
         
         Optional<?> chl = DataCall.getCacheProvider().get(URLEndpoint.V4_MASTERY_BY_CHAMPION, data);
         if (chl.isPresent())

--- a/src/test/java/no/stelar7/api/r4j/tests/lol/championmastery/ChampionMasteryTest.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/lol/championmastery/ChampionMasteryTest.java
@@ -36,6 +36,23 @@ public class ChampionMasteryTest
         
     }
     
+    @Test
+    public void testChampionMasteryWithPUUID()
+    {
+        String   id = new SpectatorBuilder().withPlatform(LeagueShard.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();
+        Summoner s  = new SummonerBuilder().withPlatform(LeagueShard.EUW1).withName(id).get();
+        
+        ChampionMastery        mastery;
+        ChampionMasteryBuilder bu = new ChampionMasteryBuilder().withPlatform(s.getPlatform()).withPUUID(s.getPUUID());
+        
+        mastery = bu.withChampionId(1).getChampionMastery();
+        assert mastery != null;
+        
+        mastery = bu.withChampionId(2).getChampionMastery();
+        assert mastery != null;
+        
+    }
+    
     
     @Test
     public void testChampionMasteryTop()

--- a/src/test/java/no/stelar7/api/r4j/tests/lol/championmastery/ChampionMasteryTest.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/lol/championmastery/ChampionMasteryTest.java
@@ -65,6 +65,16 @@ public class ChampionMasteryTest
     }
     
     @Test
+    public void testChampionMasteryTopWithPUUID()
+    {
+        String   id = new SpectatorBuilder().withPlatform(LeagueShard.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();
+        Summoner s  = new SummonerBuilder().withPlatform(LeagueShard.EUW1).withName(id).get();
+        
+        List<ChampionMastery> all = new ChampionMasteryBuilder().withPlatform(s.getPlatform()).withPUUID(s.getPUUID()).getTopChampions(null);
+        assert all != null;
+    }
+    
+    @Test
     public void testChampionMasteryAll()
     {
         String   id = new SpectatorBuilder().withPlatform(LeagueShard.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();
@@ -75,12 +85,32 @@ public class ChampionMasteryTest
     }
     
     @Test
+    public void testChampionMasteryAllWithPUUID()
+    {
+        String   id = new SpectatorBuilder().withPlatform(LeagueShard.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();
+        Summoner s  = new SummonerBuilder().withPlatform(LeagueShard.EUW1).withName(id).get();
+        
+        List<ChampionMastery> all = new ChampionMasteryBuilder().withPlatform(s.getPlatform()).withPUUID(s.getPUUID()).getChampionMasteries();
+        assert all != null;
+    }
+    
+    @Test
     public void testChampionMasteryScore()
     {
         String   id = new SpectatorBuilder().withPlatform(LeagueShard.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();
         Summoner s  = new SummonerBuilder().withPlatform(LeagueShard.EUW1).withName(id).get();
         
         Integer score = new ChampionMasteryBuilder().withPlatform(s.getPlatform()).withSummonerId(s.getSummonerId()).getMasteryScore();
+        Assertions.assertNotNull(score, "no data");
+    }
+    
+    @Test
+    public void testChampionMasteryScoreWithPUUID()
+    {
+        String   id = new SpectatorBuilder().withPlatform(LeagueShard.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();
+        Summoner s  = new SummonerBuilder().withPlatform(LeagueShard.EUW1).withName(id).get();
+        
+        Integer score = new ChampionMasteryBuilder().withPlatform(s.getPlatform()).withPUUID(s.getPUUID()).getMasteryScore();
         Assertions.assertNotNull(score, "no data");
     }
     


### PR DESCRIPTION
As Riot stated [in this tweet](https://twitter.com/RiotGamesDevRel/status/1729627427398410243), the old Champion Mastery endpoint using summonerId will be removed. I added the new PUUID version of it.

I had a code formatting problem with one of my commit, if you could pull the code and reformat it correctly to avoid a 1000 line change commit, I thank you in advance!