### PR TITLE
Bug fix Virtual Thread freeze during execution

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
@@ -230,15 +230,15 @@ public enum GameQueueType implements CodedEnum
     /**
      * BOT 5x5 games
      */
-    BOT_5X5_INTRO(830, 831, 832),
+    BOT_5X5_INTRO(830, 831, 832, 870),
     /**
      * BOT 5x5 games
      */
-    BOT_5X5_BEGINNER(840, 841, 842),
+    BOT_5X5_BEGINNER(840, 841, 842, 880),
     /**
      * BOT 5x5 games
      */
-    BOT_5X5_INTERMEDIATE(850, 851, 852),
+    BOT_5X5_INTERMEDIATE(850, 851, 852, 890),
     /**
      * Nexus Siege games
      */

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -9,6 +9,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Burst ratelimiter will use as many calls as possible, then wait when it reaches the limit
@@ -18,14 +19,17 @@ public class BurstRateLimiter extends RateLimiter
     
     private static final Logger logger = LoggerFactory.getLogger(BurstRateLimiter.class);
     
+    private ReentrantLock lock = new ReentrantLock();
+    
     public BurstRateLimiter(List<RateLimit> limits)
     {
         super(limits.toArray(new RateLimit[0]));
     }
     
     @Override
-    public synchronized void acquire()
+    public void acquire()
     {
+        lock.lock();
         try
         {
             update();
@@ -48,6 +52,9 @@ public class BurstRateLimiter extends RateLimiter
         } catch (InterruptedException e)
         {
             e.printStackTrace();
+        } finally
+        {
+            lock.unlock();
         }
     }
     

--- a/src/test/java/no/stelar7/api/r4j/tests/ratelimit/RatelimitTest.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/ratelimit/RatelimitTest.java
@@ -1,5 +1,6 @@
 package no.stelar7.api.r4j.tests.ratelimit;
 
+import no.stelar7.api.r4j.basic.calling.DataCall;
 import no.stelar7.api.r4j.basic.constants.api.regions.LeagueShard;
 import no.stelar7.api.r4j.impl.R4J;
 import no.stelar7.api.r4j.impl.lol.builders.spectator.SpectatorBuilder;
@@ -9,6 +10,8 @@ import no.stelar7.api.r4j.tests.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.*;
 
 @ExtendWith(TimingExtension.class)
@@ -21,6 +24,8 @@ public class RatelimitTest
     @Disabled
     public void testRateLimitThreaded()
     {
+
+        DataCall.setCacheProvider(null);
         try
         {
             String          name   = new SpectatorBuilder().withPlatform(LeagueShard.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();
@@ -32,6 +37,35 @@ public class RatelimitTest
             }
             pool.shutdown();
             pool.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+        } catch (InterruptedException e)
+        {
+            e.printStackTrace();
+        }
+    }
+    
+    @Test
+    @Disabled
+    public void testRateLimitVirtualThread()
+    {
+
+        DataCall.setCacheProvider(null);
+        try
+        {
+            String          name   = new SpectatorBuilder().withPlatform(LeagueShard.EUW1).getFeaturedGames().get(0).getParticipants().get(0).getSummonerName();
+            Summoner        s    = new SummonerBuilder().withPlatform(LeagueShard.EUW1).withName(name).get();
+            
+            List<Thread> threadToWait = new ArrayList<>();
+            
+            for (int i2 = 0; i2 < 130; i2++)
+            {
+                //Require Java 21
+                //threadToWait.add(Thread.ofVirtual().start(() -> new SummonerBuilder().withPlatform(LeagueShard.EUW1).withSummonerId(s.getSummonerId()).get()));
+            }
+            
+            for (Thread thread : threadToWait)
+            {
+                thread.join();
+            }
         } catch (InterruptedException e)
         {
             e.printStackTrace();


### PR DESCRIPTION
Since Java 21, virtual thread can be used as a new way to execute task in parallel. It's highly efficient for task that wait for answer from external services like here, the Riot Games API.

This PR fix a bug that was making a virtual thread to get "Pinned" and unable to change context. The new logic should be 1:1  equivalent to the old sychronized block as ReentrantLock behave the same way.