### PR TITLE
Bug fix: SPECTATOR-V5 Api is still using old data format

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/api/URLEndpoint.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/api/URLEndpoint.java
@@ -51,7 +51,7 @@ public enum URLEndpoint
     V4_SPECTATOR_CURRENT("lol", "spectator", "v4", "active-games/by-summoner/" + Constants.SUMMONER_ID_PLACEHOLDER, SpectatorGameInfo.class),
     
     V5_SPECTATOR_FEATURED("lol", "spectator", "v5", "featured-games", FeaturedGames.class),
-    V5_SPECTATOR_CURRENT("lol", "spectator", "v5", "active-games/by-summoner/v2/" + Constants.PUUID_ID_PLACEHOLDER, SpectatorConnectionInformation.class),
+    V5_SPECTATOR_CURRENT("lol", "spectator", "v5", "active-games/by-summoner/" + Constants.PUUID_ID_PLACEHOLDER, SpectatorGameInfo.class),
     
     // lol/champion-mastery/v4/champion-masteries/by-puuid/{encryptedPUUID}
     // lol/champion-mastery/v4/champion-masteries/by-puuid/{encryptedPUUID}/by-champion/{championId}

--- a/src/main/java/no/stelar7/api/r4j/impl/lol/raw/SpectatorV5API.java
+++ b/src/main/java/no/stelar7/api/r4j/impl/lol/raw/SpectatorV5API.java
@@ -5,8 +5,6 @@ import no.stelar7.api.r4j.basic.constants.api.*;
 import no.stelar7.api.r4j.basic.constants.api.regions.LeagueShard;
 import no.stelar7.api.r4j.basic.utils.Pair;
 import no.stelar7.api.r4j.pojo.lol.spectator.*;
-import no.stelar7.api.r4j.pojo.lol.spectator.v5.SpectatorConnectionInformation;
-
 import java.util.*;
 
 public final class SpectatorV5API
@@ -74,7 +72,7 @@ public final class SpectatorV5API
      * @param puuid  the puuid
      * @return SpectatorGameInfo
      */
-    public SpectatorConnectionInformation getCurrentGame(LeagueShard server, String puuid)
+    public SpectatorGameInfo getCurrentGame(LeagueShard server, String puuid)
     {
         DataCallBuilder builder = new DataCallBuilder().withURLParameter(Constants.PUUID_ID_PLACEHOLDER, puuid)
                                                        .withEndpoint(URLEndpoint.V5_SPECTATOR_CURRENT)
@@ -92,7 +90,7 @@ public final class SpectatorV5API
         
         try
         {
-            SpectatorConnectionInformation fg = (SpectatorConnectionInformation) builder.build();
+          SpectatorGameInfo fg = (SpectatorGameInfo) builder.build();
             
             data.put("value", fg);
             DataCall.getCacheProvider().store(URLEndpoint.V5_SPECTATOR_CURRENT, data);

--- a/src/test/java/no/stelar7/api/r4j/tests/lol/spectator/SpectatorV5Test.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/lol/spectator/SpectatorV5Test.java
@@ -7,7 +7,7 @@ import no.stelar7.api.r4j.basic.constants.api.regions.RegionShard;
 import no.stelar7.api.r4j.basic.constants.types.ApiKeyType;
 import no.stelar7.api.r4j.impl.R4J;
 import no.stelar7.api.r4j.impl.lol.raw.SpectatorV5API;
-import no.stelar7.api.r4j.pojo.lol.spectator.v5.SpectatorConnectionInformation;
+import no.stelar7.api.r4j.pojo.lol.spectator.SpectatorGameInfo;
 import no.stelar7.api.r4j.pojo.shared.RiotAccount;
 import no.stelar7.api.r4j.tests.SecretFile;
 
@@ -29,7 +29,7 @@ public class SpectatorV5Test
         SpectatorV5API api = r4J.getLoLAPI().getSpectatorV5API();
         RiotAccount    acc = r4J.getAccountAPI().getAccountByTag(RegionShard.EUROPE, "Incandescence33", "EUW", ApiKeyType.LOL);
         
-        SpectatorConnectionInformation currentGame = api.getCurrentGame(LeagueShard.EUW1, acc.getPUUID());
+        SpectatorGameInfo currentGame = api.getCurrentGame(LeagueShard.EUW1, acc.getPUUID());
         System.out.println(currentGame);
     }
 }

--- a/src/test/java/no/stelar7/api/r4j/tests/lol/spectator/SpectatorV5Test.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/lol/spectator/SpectatorV5Test.java
@@ -1,12 +1,15 @@
 package no.stelar7.api.r4j.tests.lol.spectator;
 
+import org.junit.jupiter.api.Test;
+
 import no.stelar7.api.r4j.basic.constants.api.regions.LeagueShard;
+import no.stelar7.api.r4j.basic.constants.api.regions.RegionShard;
+import no.stelar7.api.r4j.basic.constants.types.ApiKeyType;
 import no.stelar7.api.r4j.impl.R4J;
 import no.stelar7.api.r4j.impl.lol.raw.SpectatorV5API;
 import no.stelar7.api.r4j.pojo.lol.spectator.v5.SpectatorConnectionInformation;
-import no.stelar7.api.r4j.pojo.lol.summoner.Summoner;
+import no.stelar7.api.r4j.pojo.shared.RiotAccount;
 import no.stelar7.api.r4j.tests.SecretFile;
-import org.junit.jupiter.api.Test;
 
 public class SpectatorV5Test
 {
@@ -24,9 +27,9 @@ public class SpectatorV5Test
     {
         final R4J      r4J = new R4J(SecretFile.CREDS);
         SpectatorV5API api = r4J.getLoLAPI().getSpectatorV5API();
-        Summoner       sum = Summoner.byName(LeagueShard.EUW1, "stelar7");
+        RiotAccount    acc = r4J.getAccountAPI().getAccountByTag(RegionShard.EUROPE, "Incandescence33", "EUW", ApiKeyType.LOL);
         
-        SpectatorConnectionInformation currentGame = api.getCurrentGame(LeagueShard.EUW1, sum.getPUUID());
+        SpectatorConnectionInformation currentGame = api.getCurrentGame(LeagueShard.EUW1, acc.getPUUID());
         System.out.println(currentGame);
     }
 }


### PR DESCRIPTION
This PR changes the return format and URL of the endpoint to make it functional. The new data format previously implemented does not seem to be available.

*PS: How did you manage to see this new format? Was it temporarily online?*