### PR TITLE
ClashAPI - Change summonerId to PUUID

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashPlayer.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashPlayer.java
@@ -3,7 +3,6 @@ package no.stelar7.api.r4j.pojo.lol.clash;
 import java.io.Serializable;
 import java.util.Objects;
 
-
 public class ClashPlayer implements Serializable
 {
     private static final long serialVersionUID = 7753261596504782527L;

--- a/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashPlayer.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashPlayer.java
@@ -20,7 +20,6 @@ public class ClashPlayer implements Serializable
      * Returns the id of the team, may be null if received through a team
      * @return The teamId of the team this player is in
      */
-    @Nullable
     public String getTeamId()
     {
         return teamId;

--- a/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashPlayer.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashPlayer.java
@@ -3,19 +3,26 @@ package no.stelar7.api.r4j.pojo.lol.clash;
 import java.io.Serializable;
 import java.util.Objects;
 
+import com.mongodb.lang.Nullable;
+
 public class ClashPlayer implements Serializable
 {
     private static final long serialVersionUID = 7753261596504782527L;
-    private String summonerId;
+    private String        puuid;
     private String        teamId;
     private ClashPosition position;
     private ClashRole     role;
     
-    public String getSummonerId()
+    public String getPuuid()
     {
-        return summonerId;
+        return puuid;
     }
     
+    /**
+     * Returns the id of the team, may be null if received through a team
+     * @return The teamId of the team this player is in
+     */
+    @Nullable
     public String getTeamId()
     {
         return teamId;
@@ -43,7 +50,7 @@ public class ClashPlayer implements Serializable
             return false;
         }
         ClashPlayer that = (ClashPlayer) o;
-        return Objects.equals(summonerId, that.summonerId) &&
+        return Objects.equals(puuid, that.puuid) &&
                Objects.equals(teamId, that.teamId) &&
                position == that.position &&
                role == that.role;
@@ -52,14 +59,14 @@ public class ClashPlayer implements Serializable
     @Override
     public int hashCode()
     {
-        return Objects.hash(summonerId, teamId, position, role);
+        return Objects.hash(puuid, teamId, position, role);
     }
     
     @Override
     public String toString()
     {
         return "ClashPlayer{" +
-               "summonerId='" + summonerId + '\'' +
+               "puuid='" + puuid + '\'' +
                ", teamId='" + teamId + '\'' +
                ", position=" + position +
                ", role=" + role +

--- a/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashPlayer.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashPlayer.java
@@ -3,7 +3,6 @@ package no.stelar7.api.r4j.pojo.lol.clash;
 import java.io.Serializable;
 import java.util.Objects;
 
-import com.mongodb.lang.Nullable;
 
 public class ClashPlayer implements Serializable
 {

--- a/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashTeam.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/lol/clash/ClashTeam.java
@@ -40,6 +40,9 @@ public class ClashTeam implements Serializable
         return tier;
     }
     
+    /**
+     * @return The puuid of the captain of this team
+     */
     public String getCaptain()
     {
         return captain;

--- a/src/test/java/no/stelar7/api/r4j/tests/lol/clash/ClashTest.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/lol/clash/ClashTest.java
@@ -29,20 +29,19 @@ public class ClashTest
     @Test
     public void testGetPlayerDataByPUUID()
     {
-        RiotAccount       account  = R4J.getAccountAPI().getAccountByTag(LeagueShard.EUW1.toRegionShard(), "KaluNight", "ABM2", ApiKeyType.LOL);
-        List<ClashPlayer> stelar7  = api.getPlayerInfoByPuuid(LeagueShard.EUW1, account.getPUUID());
+        RiotAccount       account  = R4J.getAccountAPI().getAccountByTag(LeagueShard.RU.toRegionShard(), "ItSuKo69", "RU1", ApiKeyType.LOL);
+        List<ClashPlayer> stelar7  = api.getPlayerInfoByPuuid(LeagueShard.RU, account.getPUUID());
         System.out.println(stelar7);
     }
     
     @Test
     public void getTeams()
     {
-        RiotAccount       account  = R4J.getAccountAPI().getAccountByTag(LeagueShard.EUW1.toRegionShard(), "stelar7", "STL7");
-        Summoner          summoner = Summoner.byPUUID(LeagueShard.EUW1, account.getPUUID());
-        List<ClashPlayer> stelar7  = api.getPlayerInfo(LeagueShard.EUW1, summoner.getSummonerId());
-        for (ClashPlayer clashPlayer : stelar7)
+        RiotAccount       account  = R4J.getAccountAPI().getAccountByTag(LeagueShard.RU.toRegionShard(), "ItSuKo69", "RU1", ApiKeyType.LOL);
+        List<ClashPlayer> clashInfoPlayer  = api.getPlayerInfoByPuuid(LeagueShard.RU, account.getPUUID());
+        for (ClashPlayer clashPlayer : clashInfoPlayer)
         {
-            ClashTeam team = api.getTeam(LeagueShard.EUW1, clashPlayer.getTeamId());
+            ClashTeam team = api.getTeam(LeagueShard.RU, clashPlayer.getTeamId());
             System.out.println(team);
         }
     }


### PR DESCRIPTION
The api has been changed to return PUUID and not summoner ID. Tested and working well.