### PR TITLE
Fix Rate Limiter Not Working Correctly (reaching 429)

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCall.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCall.java
@@ -13,235 +13,265 @@ import java.util.prefs.Preferences;
 
 public final class DataCall
 {
-    
-    private static final Map<Enum, Map<Enum, RateLimiter>>           limiter  = new HashMap<>();
-    private static final Map<Enum, Map<Enum, Map<Integer, Integer>>> callData = new HashMap<>();
-    
-    private static APICredentials creds;
-    private static CacheProvider  cache          = EmptyCacheProvider.INSTANCE;
-    private static int            callStackSkip  = 5;
-    private static int            callStackLimit = 5;
-    private static long           maxSleep       = 10000;
-    private static int            globalTimeout  = 0;
-    
-    private final Map<String, String> urlParams  = new LinkedHashMap<>();
-    private final Map<String, String> urlData    = new LinkedHashMap<>();
-    private final Map<String, String> urlHeaders = new LinkedHashMap<>();
-    
-    private        Enum        platform;
-    private        URLEndpoint endpoint;
-    private        boolean     useLimiters       = true;
-    private        long        sleep             = -1;
-    private        int         readTimeout       = 0;
-    private        int         connectTimeout    = 0;
-    private        boolean     returnRawResponse = false;
-    private        LeagueShard defaultPlatform   = LeagueShard.EUW1;
-    private        String      urlProxy          = Constants.REQUEST_URL;
-    private static Preferences ratelimiterCache  = Preferences.userRoot().node("no/stelar7/r4j");
-    
-    public static Map<Enum, Map<Enum, RateLimiter>> getLimiter()
-    {
-        return limiter;
-    }
-    
-    public static Map<Enum, Map<Enum, Map<Integer, Integer>>> getCallData()
-    {
-        return callData;
-    }
-    
-    public static Preferences getRatelimiterCache()
-    {
-        return ratelimiterCache;
-    }
-    
-    public Map<String, String> getUrlParams()
-    {
-        return urlParams;
-    }
-    
-    public Map<String, String> getUrlData()
-    {
-        return urlData;
-    }
-    
-    public Map<String, String> getUrlHeaders()
-    {
-        return urlHeaders;
-    }
-    
-    public Enum getPlatform()
-    {
-        if (platform == null)
-        {
-            return defaultPlatform;
-        }
-        if (platform == LeagueShard.UNKNOWN)
-        {
-            return defaultPlatform;
-        }
-        return platform;
-    }
-    
-    public URLEndpoint getEndpoint()
-    {
-        return endpoint;
-    }
-    
-    public void setPlatform(Enum platform)
-    {
-        this.platform = platform;
-    }
-    
-    public void setUseLimiters(boolean flag)
-    {
-        this.useLimiters = flag;
-    }
-    
-    public void setEndpoint(URLEndpoint endpoint)
-    {
-        this.endpoint = endpoint;
-    }
-    
-    public void setMaxSleep(long sleep)
-    {
-        this.sleep = sleep;
-    }
-    
-    public long getMaxSleep()
-    {
-        return this.sleep != -1 ? this.sleep : DataCall.getDefaultMaxSleep();
-    }
-    
-    public static DataCallBuilder builder()
-    {
-        return new DataCallBuilder();
-    }
-    
-    public static APICredentials getCredentials()
-    {
-        return DataCall.creds;
-    }
-    
-    public static CacheProvider getCacheProvider()
-    {
-        return cache;
-    }
-    
-    public static void setCacheProvider(CacheProvider provider)
-    {
-        cache = provider == null ? EmptyCacheProvider.INSTANCE : provider;
-    }
-    
-    public static void setCredentials(final APICredentials creds)
-    {
-        DataCall.creds = creds;
-    }
-    
-    /**
-     * Takes in a proxy for the api.
-     * The URL should contain the parts:
-     * {platform}
-     * {game}
-     * {service}
-     * {version}
-     * {resource}
-     * <p>
-     * The default is https://{platform}.api.riotgames.com/{game}/{service}/{version}/{resource}
-     *
-     * @param proxy the url
-     */
-    public void setProxy(String proxy)
-    {
-        urlProxy = proxy == null ? Constants.REQUEST_URL : proxy;
-    }
-    
-    public String getProxy()
-    {
-        return urlProxy;
-    }
-    
-    public LeagueShard getDefaultPlatform()
-    {
-        return defaultPlatform;
-    }
-    
-    public void setDefaultPlatform(LeagueShard defaultPlatform)
-    {
-        this.defaultPlatform = defaultPlatform;
-    }
-    
-    public static int getCallStackSkip()
-    {
-        return callStackSkip;
-    }
-    
-    public static void setCallStackSkip(int callStackSkip)
-    {
-        DataCall.callStackSkip = callStackSkip;
-    }
-    
-    public static int getCallStackLimit()
-    {
-        return callStackLimit;
-    }
-    
-    public static void setCallStackLimit(int callStackLimit)
-    {
-        DataCall.callStackLimit = callStackLimit;
-    }
-    
-    public boolean useRatelimiter()
-    {
-        return useLimiters;
-    }
-    
-    public static void setDefaultMaxSleep(long sleep)
-    {
-        DataCall.maxSleep = sleep;
-    }
-    
-    public static long getDefaultMaxSleep()
-    {
-        return DataCall.maxSleep;
-    }
-    
-    public int getReadTimeout()
-    {
-        return readTimeout == 0 ? globalTimeout : readTimeout;
-    }
-    
-    public void setReadTimeout(int readTimeout)
-    {
-        this.readTimeout = readTimeout;
-    }
-    
-    public int getConnectTimeout()
-    {
-        return connectTimeout == 0 ? globalTimeout : connectTimeout;
-    }
-    
-    public void setConnectTimeout(int connectTimeout)
-    {
-        this.connectTimeout = connectTimeout;
-    }
-    
-    public static int getGlobalTimeout()
-    {
-        return globalTimeout;
-    }
-    
-    public static void setGlobalTimeout(int globalTimeout)
-    {
-        DataCall.globalTimeout = globalTimeout;
-    }
-    
-    public boolean shouldReturnRawResponse()
-    {
-        return returnRawResponse;
-    }
-    
-    public void setShouldReturnRawResponse(boolean returnRawResponse)
-    {
-        this.returnRawResponse = returnRawResponse;
-    }
+
+	// Maps for storing limiters
+	private static final Map<String, Map<Enum, Map<Enum, RateLimiter>>> limitersByKeyType = new HashMap<>();
+
+	private static final Map<Enum, Map<Enum, Map<Integer, Integer>>> callData = new HashMap<>();
+
+	private static APICredentials creds;
+	private static CacheProvider  cache          = EmptyCacheProvider.INSTANCE;
+	private static int            callStackSkip  = 5;
+	private static int            callStackLimit = 5;
+	private static long           maxSleep       = 10000;
+	private static int            globalTimeout  = 0;
+
+	private final Map<String, String> urlParams  = new LinkedHashMap<>();
+	private final Map<String, String> urlData    = new LinkedHashMap<>();
+	private final Map<String, String> urlHeaders = new LinkedHashMap<>();
+
+	private        Enum        platform;
+	private        URLEndpoint endpoint;
+	private        boolean     useLimiters       = true;
+	private        long        sleep             = -1;
+	private        int         readTimeout       = 0;
+	private        int         connectTimeout    = 0;
+	private        boolean     returnRawResponse = false;
+	private        LeagueShard defaultPlatform   = LeagueShard.EUW1;
+	private        String      urlProxy          = Constants.REQUEST_URL;
+	private static Preferences ratelimiterCache  = Preferences.userRoot().node("no/stelar7/r4j");
+
+	public static Map<Enum, Map<Enum, RateLimiter>> getLimiter(String game)
+	{
+		DataCallBuilder.getGlobalLock().lock();
+		try {
+			return limitersByKeyType.computeIfAbsent(game, k -> new HashMap<>());
+		} finally {
+			DataCallBuilder.getGlobalLock().unlock();
+		}
+	}
+
+	public static Map<Enum, Map<Enum, Map<Integer, Integer>>> getCallData()
+	{
+		return callData;
+	}
+
+	public static Preferences getRatelimiterCache()
+	{
+		return ratelimiterCache;
+	}
+
+	public Map<String, String> getUrlParams()
+	{
+		return urlParams;
+	}
+
+	public Map<String, String> getUrlData()
+	{
+		return urlData;
+	}
+
+	public Map<String, String> getUrlHeaders()
+	{
+		return urlHeaders;
+	}
+
+	public String getKeyUsedByHeadersUsed() {
+		String keyUsed = urlHeaders.get(Constants.X_RIOT_TOKEN_HEADER_KEY);
+
+		if (keyUsed == null || keyUsed.isEmpty())
+		{
+			return "unknown";
+		}
+
+		if (keyUsed.equals(creds.getLoLAPIKey())){
+			return "lol";
+		} else if (keyUsed.equals(creds.getTFTAPIKey())) {
+			return "tft";
+		} else if (keyUsed.equals(creds.getVALAPIKey())) {
+			return "val";
+		} else if (keyUsed.equals(creds.getLORAPIKey())) {
+			return "lor";
+		}else if (keyUsed.equals(creds.getTournamentAPIKey())) {
+			return "tournament";
+		}
+
+		return "other";
+	}
+
+	public Enum getPlatform()
+	{
+		if (platform == null)
+		{
+			return defaultPlatform;
+		}
+		if (platform == LeagueShard.UNKNOWN)
+		{
+			return defaultPlatform;
+		}
+		return platform;
+	}
+
+	public URLEndpoint getEndpoint()
+	{
+		return endpoint;
+	}
+
+	public void setPlatform(Enum platform)
+	{
+		this.platform = platform;
+	}
+
+	public void setUseLimiters(boolean flag)
+	{
+		this.useLimiters = flag;
+	}
+
+	public void setEndpoint(URLEndpoint endpoint)
+	{
+		this.endpoint = endpoint;
+	}
+
+	public void setMaxSleep(long sleep)
+	{
+		this.sleep = sleep;
+	}
+
+	public long getMaxSleep()
+	{
+		return this.sleep != -1 ? this.sleep : DataCall.getDefaultMaxSleep();
+	}
+
+	public static DataCallBuilder builder()
+	{
+		return new DataCallBuilder();
+	}
+
+	public static APICredentials getCredentials()
+	{
+		return DataCall.creds;
+	}
+
+	public static CacheProvider getCacheProvider()
+	{
+		return cache;
+	}
+
+	public static void setCacheProvider(CacheProvider provider)
+	{
+		cache = provider == null ? EmptyCacheProvider.INSTANCE : provider;
+	}
+
+	public static void setCredentials(final APICredentials creds)
+	{
+		DataCall.creds = creds;
+	}
+
+	/**
+	 * Takes in a proxy for the api.
+	 * The URL should contain the parts:
+	 * {platform}
+	 * {game}
+	 * {service}
+	 * {version}
+	 * {resource}
+	 * <p>
+	 * The default is https://{platform}.api.riotgames.com/{game}/{service}/{version}/{resource}
+	 *
+	 * @param proxy the url
+	 */
+	public void setProxy(String proxy)
+	{
+		urlProxy = proxy == null ? Constants.REQUEST_URL : proxy;
+	}
+
+	public String getProxy()
+	{
+		return urlProxy;
+	}
+
+	public LeagueShard getDefaultPlatform()
+	{
+		return defaultPlatform;
+	}
+
+	public void setDefaultPlatform(LeagueShard defaultPlatform)
+	{
+		this.defaultPlatform = defaultPlatform;
+	}
+
+	public static int getCallStackSkip()
+	{
+		return callStackSkip;
+	}
+
+	public static void setCallStackSkip(int callStackSkip)
+	{
+		DataCall.callStackSkip = callStackSkip;
+	}
+
+	public static int getCallStackLimit()
+	{
+		return callStackLimit;
+	}
+
+	public static void setCallStackLimit(int callStackLimit)
+	{
+		DataCall.callStackLimit = callStackLimit;
+	}
+
+	public boolean useRatelimiter()
+	{
+		return useLimiters;
+	}
+
+	public static void setDefaultMaxSleep(long sleep)
+	{
+		DataCall.maxSleep = sleep;
+	}
+
+	public static long getDefaultMaxSleep()
+	{
+		return DataCall.maxSleep;
+	}
+
+	public int getReadTimeout()
+	{
+		return readTimeout == 0 ? globalTimeout : readTimeout;
+	}
+
+	public void setReadTimeout(int readTimeout)
+	{
+		this.readTimeout = readTimeout;
+	}
+
+	public int getConnectTimeout()
+	{
+		return connectTimeout == 0 ? globalTimeout : connectTimeout;
+	}
+
+	public void setConnectTimeout(int connectTimeout)
+	{
+		this.connectTimeout = connectTimeout;
+	}
+
+	public static int getGlobalTimeout()
+	{
+		return globalTimeout;
+	}
+
+	public static void setGlobalTimeout(int globalTimeout)
+	{
+		DataCall.globalTimeout = globalTimeout;
+	}
+
+	public boolean shouldReturnRawResponse()
+	{
+		return returnRawResponse;
+	}
+
+	public void setShouldReturnRawResponse(boolean returnRawResponse)
+	{
+		this.returnRawResponse = returnRawResponse;
+	}
 }

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -583,11 +583,15 @@ public class DataCallBuilder
 			String appB    = con.getHeaderField("X-App-Rate-Limit-Count");
 			String methodA = con.getHeaderField("X-Method-Rate-Limit");
 			String methodB = con.getHeaderField("X-Method-Rate-Limit-Count");
-
 			
 			// Quickly notify if a ratelimit was hit, we don't wait on any lock
 			if (con.getResponseCode() == 429)
 			{
+				logger.debug("Debug: all headers: {}", con.getHeaderFields());
+				
+				logger.warn("Ratelimit hit for platform: {}, endpoint: {}, method: {}, app limit: {}/{}, method limit: {}/{}",
+				            this.dc.getPlatform(), this.dc.getEndpoint(), this.requestMethod, appB, appA, methodB, methodA);
+				
 				final RateLimitType limitType = RateLimitType.getBestMatch(con.getHeaderField("X-Rate-Limit-Type"));
 
 				if (limitType == RateLimitType.LIMIT_METHOD)

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -28,857 +28,857 @@ import java.util.prefs.BackingStoreException;
 @SuppressWarnings("rawtypes")
 public class DataCallBuilder
 {
-  private static final int NUMBER_OF_CALLS_ALLOWED_IN_ASYNC = 200;
-
-  private static final Logger logger = LoggerFactory.getLogger(DataCallBuilder.class);
-
-  private final DataCall dc = new DataCall();
-
-  private static final BiFunction<String, String, String> MERGE        = (o, n) -> o + "," + n;
-  private static final BiFunction<String, String, String> MERGE_AS_SET = (o, n) -> o + n;
-
-  private String requestMethod = "GET";
-  private String postData      = "";
-
-  private Semaphore semaphore = new Semaphore(NUMBER_OF_CALLS_ALLOWED_IN_ASYNC, true);
-
-  private static final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager()
-  {
-    public java.security.cert.X509Certificate[] getAcceptedIssuers()
-    {
-      return null;
-    }
-
-    public void checkClientTrusted(X509Certificate[] certs, String authType)
-    {
-    }
-
-    public void checkServerTrusted(X509Certificate[] certs, String authType)
-    {
-    }
-  }
-  };
-
-  // Create all-trusting host name verifier
-  private static final HostnameVerifier allHostsValid = (hostname, session) -> true;
-
-  static
-  {
-    try
-    {
-      // Install the all-trusting trust manager
-      SSLContext sc = SSLContext.getInstance("SSL");
-      sc.init(null, trustAllCerts, new java.security.SecureRandom());
-      HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-    } catch (KeyManagementException | NoSuchAlgorithmException e)
-    {
-      e.printStackTrace();
-    }
-  }
-
-
-  private static void updateRatelimiter(Enum server, Enum endpoint)
-  {
-    RateLimiter limiter = DataCall.getLimiter().get(server).get(endpoint);
-    limiter.updatePermitsTakenPerX(DataCall.getCallData().get(server).get(endpoint));
-  }
-
-  private static final Map<URLEndpoint, AtomicLong> requestCount = new HashMap<>();
-
-  /**
-   * Puts together all the data, and then returns an object representing the JSON from the call
-   *
-   * @param retrys the amount of retries already done (should not be passed in!)
-   * @return an object generated from the requested JSON
-   */
-  public Object build(int... retrys)
-  {
-    final String url = this.getURL();
-
-    try {
-      semaphore.acquire();
-      if (this.dc.useRatelimiter())
-      {
-        if (DataCall.getCredentials() == null)
-        {
-          throw new APIUnsupportedActionException("No API Creds set!");
-        }
-
-        dc.getUrlHeaders().putIfAbsent("X-Riot-Token", DataCall.getCredentials().getLoLAPIKey());
-
-        // app limit
-        applyLimit(this.dc.getPlatform(), this.dc.getPlatform());
-        // method limit
-        applyLimit(this.dc.getPlatform(), this.dc.getEndpoint());
-      }
-
-
-      logger.info("Trying url: {}", url);
-
-      final DataCallResponse response = this.getResponse(url);
-      //logger.debug(response.toString());
-
-      switch (response.getResponseCode())
-      {
-      case 200:
-      case 201:
-      case 204:
-      {
-        String returnValue = response.getResponseData();
-
-        if (this.dc.shouldReturnRawResponse())
-        {
-          return returnValue;
-        }
-
-        if (this.dc.getEndpoint() != null)
-        {
-          final Class<?> returnType = this.dc.getEndpoint().getType();
-          returnValue = postProcess(returnValue);
-
-          return Utils.getGson().fromJson(returnValue, returnType);
-        } else
-        {
-          return returnValue;
-        }
-      }
-
-      case 400:
-      {
-        String reasonText = "Your api request is malformed!\n";
-        reasonText += url + "\n";
-        throw new APIResponseException(APIHTTPErrorReason.ERROR_400, reasonText + response.getResponseData());
-      }
-
-      case 401:
-      {
-
-        String reasonText = "The API denied your request!\n";
-        reasonText += "Your API key was not present in the request\n";
-        reasonText += "Make sure you have setup your APICredentials before doing a API call!\n";
-        throw new APIResponseException(APIHTTPErrorReason.ERROR_401, reasonText + response.getResponseData());
-      }
-
-      case 403:
-      {
-
-        String reasonText = "The API denied your request!\n";
-        reasonText += "Possible reasons:\n";
-        reasonText += " - Your API key is invalid\n";
-        reasonText += " - You just regenerated the key; wait a few seconds, then try again\n";
-        reasonText += " - You are trying to call a endpoint you dont have access to\n";
-        throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
-      }
-
-      case 404:
-      {
-        return new Pair<>(response.getResponseCode(), response.getResponseData());
-      }
-
-      case 405:
-      {
-        String reasonText = "The API was unable to handle your request due to the wrong HTTP method being used.\n";
-        throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
-      }
-      case 429:
-        if (response.getResponseData().startsWith(RateLimitType.LIMIT_UNDERLYING.getReason()) || response.getResponseData().startsWith(RateLimitType.LIMIT_SERVICE.getReason()))
-        {
-          return sleepAndRetry(retrys, response.getResponseCode());
-        } else
-        {
-          String error = response.getResponseData() + "429 ratelimit hit! " +
-              "Please do not restart your application to refresh the timer! " +
-              "This isn't supposed to happen unless you restarted your app before the last limit was hit!";
-
-          logger.error(error);
-
-        }
-
-        return this.build();
-
-      case 500:
-      case 502:
-      case 503:
-      case 504:
-      {
-        return sleepAndRetry(retrys, response.getResponseCode());
-      }
-
-      case 599:
-      {
-        throw new APIResponseException(APIHTTPErrorReason.ERROR_599, response.getResponseData());
-      }
-
-      default:
-      {
-        break;
-      }
-      }
-
-      System.err.println("UNHANDLED RESPONSE CODE!!!");
-      System.err.println("Response Code:" + response.getResponseCode());
-      System.err.println("Response Data:" + response.getResponseData());
-      throw new APINoValidResponseException(response.getResponseData());
-    } catch (InterruptedException e) {
-      logger.error("Semaphore was interrupted while trying to acquire a permit for the API call: {}", url, e);
-      Thread.currentThread().interrupt();
-      return null;
-    }finally {
-      semaphore.release();
-    }
-  }
-
-  private String postProcess(String returnValue)
-  {
-    final List<URLEndpoint> ddragon = Arrays.asList(URLEndpoint.DDRAGON_CHAMPION_MANY, URLEndpoint.DDRAGON_SUMMONER_SPELLS);
-    if (ddragon.contains(this.dc.getEndpoint()))
-    {
-      returnValue = postProcessDDragonMany(returnValue);
-    }
-
-    if (this.dc.getEndpoint() == URLEndpoint.DDRAGON_ITEMS || this.dc.getEndpoint() == URLEndpoint.DDRAGON_RUNES)
-    {
-      returnValue = postProcessDDragonAddId(returnValue);
-    }
-
-    final List<URLEndpoint> summonerEndpoints = Arrays.asList(
-        URLEndpoint.V4_SUMMONER_BY_ACCOUNT,
-        URLEndpoint.V4_SUMMONER_BY_ID,
-        URLEndpoint.V4_SUMMONER_BY_PUUID,
-        URLEndpoint.V1_TFT_SUMMONER_BY_ACCOUNT,
-        URLEndpoint.V1_TFT_SUMMONER_BY_ID,
-        URLEndpoint.V1_TFT_SUMMONER_BY_PUUID);
-    if (summonerEndpoints.contains(this.dc.getEndpoint()))
-    {
-      returnValue = postProcessSummoner(returnValue);
-    }
-
-    final List<URLEndpoint> apexEndpoints = Arrays.asList(URLEndpoint.V4_LEAGUE_MASTER, URLEndpoint.V4_LEAGUE_GRANDMASTER, URLEndpoint.V4_LEAGUE_CHALLENGER,
-        URLEndpoint.V1_TFT_LEAGUE_MASTER, URLEndpoint.V1_TFT_LEAGUE_GRANDMASTER, URLEndpoint.V1_TFT_LEAGUE_CHALLENGER);
-    if (apexEndpoints.contains(this.dc.getEndpoint()))
-    {
-      returnValue = postProcessApex(returnValue);
-    }
-
-    return returnValue;
-  }
-
-  private String postProcessApex(String returnValue)
-  {
-    JsonObject elem    = (JsonObject) JsonParser.parseString(returnValue);
-    JsonArray  entries = elem.getAsJsonArray("entries");
-    if (entries == null)
-    {
-      entries = new JsonArray();
-    }
-
-    entries.forEach(e -> {
-      JsonObject ob = (JsonObject) e;
-      ob.add("leagueId", elem.get("leagueId"));
-      ob.add("queueType", elem.get("queue"));
-      ob.add("tier", elem.get("tier"));
-    });
-
-    return Utils.getGson().toJson(elem);
-  }
-
-  private String postProcessDDragonMany(String returnValue)
-  {
-    JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
-    JsonObject parent = elem.getAsJsonObject("data");
-    for (String key : new HashSet<>(parent.keySet()))
-    {
-      JsonObject child = parent.getAsJsonObject(key);
-      String     id    = child.get("key").getAsString();
-      child.addProperty("key", key);
-      child.addProperty("id", id);
-      parent.add(id, child);
-      parent.remove(key);
-    }
-
-    return Utils.getGson().toJson(elem);
-  }
-
-  private String postProcessDDragonAddId(String returnValue)
-  {
-    JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
-    JsonObject parent = elem.getAsJsonObject("data");
-    for (String key : new HashSet<>(parent.keySet()))
-    {
-      JsonObject child = parent.getAsJsonObject(key);
-      try 
-      {
-        int keyAsInt = Integer.parseInt(key);
-        child.addProperty("id", keyAsInt);
-
-      }   catch(NumberFormatException e) 
-      {
-        parent.remove(key);
-        logger.warn("Item/Rune received without a valid Id ({}), item removed from the list", key);
-      }
-    }
-
-    return Utils.getGson().toJson(elem);
-  }
-
-  private String postProcessPerkPath(String returnValue)
-  {
-    JsonObject elem     = (JsonObject) JsonParser.parseString(returnValue);
-    String     pathName = elem.get("name").getAsString();
-    String     pathId   = elem.get("id").getAsString();
-
-    JsonArray slots = elem.getAsJsonArray("slots");
-    for (JsonElement slot : slots)
-    {
-      JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
-      for (JsonElement rune : runes)
-      {
-        JsonObject obj = (JsonObject) rune;
-        obj.addProperty("runePathName", pathName);
-        obj.addProperty("runePathId", pathId);
-      }
-    }
-
-    return Utils.getGson().toJson(elem);
-  }
-
-  private String postProcessPerkPaths(String returnValue)
-  {
-    JsonArray element = (JsonArray) JsonParser.parseString(returnValue);
-
-    for (JsonElement elem : element)
-    {
-      String pathName = elem.getAsJsonObject().get("name").getAsString();
-      String pathId   = elem.getAsJsonObject().get("id").getAsString();
-
-      JsonArray slots = elem.getAsJsonObject().getAsJsonArray("slots");
-      for (JsonElement slot : slots)
-      {
-        JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
-        for (JsonElement rune : runes)
-        {
-          JsonObject obj = (JsonObject) rune;
-          obj.addProperty("runePathName", pathName);
-          obj.addProperty("runePathId", pathId);
-        }
-      }
-    }
-
-    return Utils.getGson().toJson(element);
-  }
-
-  private String postProcessSummoner(String returnValue)
-  {
-    JsonObject element = (JsonObject) JsonParser.parseString(returnValue);
-    element.addProperty("platform", this.dc.getPlatform().toString());
-    return Utils.getGson().toJson(element);
-  }
-
-  private Object sleepAndRetry(int[] retrys, int errorCode)
-  {
-    try
-    {
-      int  attempts           = (retrys != null && retrys.length == 1) ? ++retrys[0] : 1;
-      long nextSleepDuration  = attempts * 500L;
-      long totalSleepDuration = 0;
-      for (int i = 1; i < attempts; i++)
-      {
-        totalSleepDuration += i * 500L;
-      }
-
-
-      String message = "";
-      if (errorCode == 429)
-      {
-        message = "Ratelimit reached too many times, waiting " + nextSleepDuration / 1000 + " seconds then retrying";
-      } else
-      {
-        message = "Server error (" + errorCode + ") , waiting " + nextSleepDuration / 1000 + " seconds then retrying";
-      }
-
-      logger.info(message);
-
-      if (totalSleepDuration > this.dc.getMaxSleep())
-      {
-        throw new APINoValidResponseException(String.format("API did not return a valid response in time. Total sleep time is over the max sleep value %s > %s...\n" +
-            "Try setting `DataCall.setDefaultMaxSleep(long)` to a larger number (default is 10000)",
-            (nextSleepDuration + totalSleepDuration), this.dc.getMaxSleep()));
-      }
-
-      Thread.sleep(nextSleepDuration);
-      return this.build(attempts);
-    } catch (InterruptedException e)
-    {
-      throw new APINoValidResponseException("Something interupted the API timeout;" + e.getMessage());
-    }
-  }
-
-  public static final ReentrantLock lock = new ReentrantLock();
-
-  private void applyLimit(Enum platform, Enum endpoint)
-  {
-    lock.lock();
-    try
-    {
-      Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
-
-      if (child.get(endpoint) == null)
-      {
-        loadLimiterFromCache(platform, endpoint, child);
-      }
-    } finally
-    {
-      lock.unlock();
-    }
-
-    RateLimiter limitr = DataCall.getLimiter().getOrDefault(platform, new HashMap<>()).get(endpoint);
-
-    if (limitr != null)
-    {
-      limitr.acquire();
-      storeLimiter(platform, endpoint);
-    }
-  }
-
-  private void storeLimiter(Enum platform, Enum endpoint)
-  {
-    RateLimiter limiter  = DataCall.getLimiter().get(platform).get(endpoint);
-    String      baseKey  = platform.toString() + "/" + endpoint.toString();
-    String      limitKey = "limits/" + baseKey;
-    String      firstKey = "first/" + baseKey;
-    String      callKey  = "call/" + baseKey;
-
-    DataCall.getRatelimiterCache().put(firstKey, Utils.getGson().toJson(limiter.getFirstCallInTime()));
-    DataCall.getRatelimiterCache().put(callKey, Utils.getGson().toJson(limiter.getCallCountInTime()));
-  }
-
-  private void loadLimiterFromCache(Enum platform, Enum endpoint, Map<Enum, RateLimiter> child)
-  {
-    String baseKey  = platform.toString() + "/" + endpoint.toString();
-    String limitKey = "limits/" + baseKey;
-    String firstKey = "first/" + baseKey;
-    String callKey  = "call/" + baseKey;
-
-    String lastLimit = DataCall.getRatelimiterCache().get(limitKey, null);
-    String lastFirst = DataCall.getRatelimiterCache().get(firstKey, null);
-    String lastKey   = DataCall.getRatelimiterCache().get(callKey, null);
-
-    if (lastLimit == null)
-    {
-      logger.debug("No instance of an old ratelimiter found");
-      return;
-    } else
-    {
-      logger.debug("Loading old ratelimiter data");
-    }
-
-    try
-    {
-      List<RateLimit>            knownLimits = Utils.getGson().fromJson(lastLimit, new TypeToken<List<RateLimit>>() {}.getType());
-      Map<RateLimit, AtomicLong> knownTime   = Utils.getGson().fromJson(lastFirst, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
-      Map<RateLimit, AtomicLong> knownCount  = Utils.getGson().fromJson(lastKey, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
-
-
-      RateLimiter newerLimit = new BurstRateLimiter(knownLimits);
-      newerLimit.setCallCountInTime(knownCount);
-      newerLimit.setFirstCallInTime(knownTime);
-
-      logger.debug("Loaded ratelimit for {}", endpoint);
-
-      child.put(endpoint, newerLimit);
-      DataCall.getLimiter().put(platform, child);
-    } catch (JsonSyntaxException s)
-    {
-      try
-      {
-        logger.debug("Old ratelimiter was of incompatible type, re-creating");
-        DataCall.getRatelimiterCache().clear();
-        DataCall.getRatelimiterCache().sync();
-      } catch (BackingStoreException e)
-      {
-        e.printStackTrace();
-      }
-    }
-  }
-
-
-  /**
-   * Opens a connection to the URL, then reads the data into a Response.
-   *
-   * @param url the URL to call
-   * @return a DataCallResponse with the data from the call
-   * @throws APINoValidResponseException if the datacall failed in any fashion
-   */
-  private DataCallResponse getResponse(final String url)
-  {
-    final StringBuilder data = new StringBuilder();
-    try
-    {
-      final HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
-
-      con.setUseCaches(false);
-      con.setDefaultUseCaches(false);
-      con.setRequestProperty("User-Agent", "R4J");
-      con.setRequestProperty("Accept-Charset", "ISO-8859-1,utf-8");
-      con.setRequestProperty("Accept-Language", "en-US");
-      con.setRequestProperty("Cache-Control", "no-store,max-age=0,no-cache");
-      con.setRequestProperty("Expires", "0");
-      con.setRequestProperty("Pragma", "no-cache");
-      con.setRequestProperty("Connection", "keep-alive");
-      con.setRequestProperty("Content-Type", "application/json");
-      con.setConnectTimeout(this.dc.getConnectTimeout());
-      con.setReadTimeout(this.dc.getReadTimeout());
-      this.dc.getUrlHeaders().forEach(con::setRequestProperty);
-
-      if (requestMethod.equalsIgnoreCase("PATCH"))
-      {
-        con.setRequestProperty("X-HTTP-Method-Override", "PATCH");
-        con.setRequestMethod("POST");
-      } else
-      {
-        con.setRequestMethod(requestMethod);
-      }
-
-      StringBuilder sb = new StringBuilder();
-      con.getRequestProperties().forEach((key, value) -> sb.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
-
-      String printMe = new StringBuilder("\n")
-          .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Url", url)).append("\n")
-          .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Method", con.getRequestMethod())).append("\n")
-          .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "POST data", this.postData)).append("\n")
-          .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Headers", "")).append("\n")
-          .append(sb).toString();
-
-      //logger.debug(printMe);
-
-
-      if (null != this.postData && !this.postData.isEmpty())
-      {
-        con.setDoOutput(true);
-        final DataOutputStream writer = new DataOutputStream(con.getOutputStream());
-        writer.writeBytes(this.postData);
-        writer.flush();
-        writer.close();
-      }
-
-      con.connect();
-
-      StringBuilder sb2 = new StringBuilder("\n");
-      con.getHeaderFields().forEach((key, value) -> sb2.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
-
-      String printMe2 = new StringBuilder("\n").append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Response Headers", ""))
-          .append(sb2)
-          .toString();
-      //logger.debug(printMe2);
-
-
-      String appA    = con.getHeaderField("X-App-Rate-Limit");
-      String appB    = con.getHeaderField("X-App-Rate-Limit-Count");
-      String methodA = con.getHeaderField("X-Method-Rate-Limit");
-      String methodB = con.getHeaderField("X-Method-Rate-Limit-Count");
-
-      if (appA == null)
-      {
-        logger.debug("Header 'X-App-Rate-Limit' missing from call: {} ", getURL());
-      } else
-      {
-        lock.lock();
-        createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
-        saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
-        lock.unlock();
-      }
-
-      if (methodA == null)
-      {
-        logger.debug("Header 'X-Method-Rate-Limit' missing from call: {}", getURL());
-      } else
-      {
-        lock.lock();
-        createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
-        saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
-        lock.unlock();
-      }
-
-      String deprecationHeader = con.getHeaderField("X-Riot-Deprecated");
-      if (deprecationHeader != null)
-      {
-        LocalDateTime timeout = LocalDateTime.ofEpochSecond(Long.parseLong(deprecationHeader) / 1000, 0, ZoneOffset.ofHours(-7));
-        logger.info("You are using a deprecated method, this method will stop working at: {}", timeout);
-      }
-
-      if (con.getResponseCode() == 429)
-      {
-        final RateLimitType limitType = RateLimitType.getBestMatch(con.getHeaderField("X-Rate-Limit-Type"));
-
-        StringBuilder valueList = new StringBuilder();
-        DataCall.getLimiter().get(dc.getPlatform()).forEach((key, value) -> {
-          valueList.append(key);
-          valueList.append("=");
-          valueList.append(value.getCallCountInTime());
-          valueList.append("\n");
-        });
-
-        String reasonString = String.format("%s%n%s", limitType.getReason(), valueList.toString().trim());
-        String reason       = String.format("%s%n", reasonString);
-
-        if (limitType == RateLimitType.LIMIT_METHOD)
-        {
-          RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getEndpoint());
-          limter.updateSleep(con.getHeaderField("Retry-After"));
-        }
-
-        if (limitType == RateLimitType.LIMIT_USER)
-        {
-
-          RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getPlatform());
-          limter.updateSleep(con.getHeaderField("Retry-After"));
-        }
-
-        return new DataCallResponse(con.getResponseCode(), reason);
-      }
-
-      if (con.getResponseCode() == 204)
-      {
-        return new DataCallResponse(con.getResponseCode(), "");
-      }
-
-      InputStream stream = (con.getResponseCode() <= 399) ? con.getInputStream() : con.getErrorStream();
-
-      if (stream == null)
-      {
-        return new DataCallResponse(con.getResponseCode(), "Unable to read stream!");
-      }
-
-      try (BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)))
-      {
-        br.lines().forEach(data::append);
-      }
-
-      con.disconnect();
-
-      return new DataCallResponse(con.getResponseCode(), data.toString());
-    } catch (final IOException e)
-    {
-      throw new APIResponseException(APIHTTPErrorReason.ERROR_599, APIHTTPErrorReason.ERROR_599.getReason());
-    }
-  }
-
-  private void createRatelimiterIfMissing(String methodA, Enum platform, Enum endpoint)
-  {
-    Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
-
-    RateLimiter oldLimit   = child.get(endpoint);
-    RateLimiter newerLimit = createLimiter(methodA);
-
-    if (!newerLimit.equals(oldLimit))
-    {
-      newerLimit.mergeFrom(oldLimit);
-      child.put(endpoint, newerLimit);
-
-      logger.debug("Updating Ratelimit For {}", endpoint);
-      logger.debug(newerLimit.getLimits().toString());
-    }
-
-    DataCall.getLimiter().put(platform, child);
-  }
-
-  private void saveHeaderRateLimit(String limitCount, Enum platform, Enum endpoint)
-  {
-    Map<Enum, Map<Integer, Integer>> parent = DataCall.getCallData().getOrDefault(platform, new HashMap<>());
-    Map<Integer, Integer>            child  = parent.getOrDefault(endpoint, new HashMap<>());
-
-    child.putAll(parseLimitFromHeader(limitCount));
-    parent.put(endpoint, child);
-    DataCall.getCallData().put(platform, parent);
-
-    updateRatelimiter(platform, endpoint);
-    storeLimiter(platform, endpoint);
-  }
-
-  private Map<Integer, Integer> parseLimitFromHeader(String headerValue)
-  {
-    final String[]        limits  = headerValue.split(",");
-    Map<Integer, Integer> timeout = new HashMap<>();
-    for (final String limitPair : limits)
-    {
-      final String[] limit = limitPair.split(":");
-      final Integer  call  = Integer.parseInt(limit[0]);
-      final Integer  time  = Integer.parseInt(limit[1]);
-      timeout.put(time, call);
-    }
-
-    return timeout;
-  }
-
-  public RateLimiter createLimiter(String limitCount)
-  {
-    Map<Integer, Integer> timeout = parseLimitFromHeader(limitCount);
-
-    List<RateLimit> limits = new ArrayList<>();
-    for (Entry<Integer, Integer> entry : timeout.entrySet())
-    {
-      limits.add(new RateLimit(entry.getValue(), entry.getKey(), TimeUnit.SECONDS));
-    }
-
-    return new BurstRateLimiter(limits);
-  }
-
-  /**
-   * Generates the URL to use for the call.
-   *
-   * @return the URL to use for the call.
-   */
-  private String getURL()
-  {
-    String[] url = {dc.getProxy()};
-    if (dc.getEndpoint() != null)
-    {
-      url[0] = url[0].replace(Constants.GAME_PLACEHOLDER, dc.getEndpoint().getGame());
-      url[0] = url[0].replace(Constants.SERVICE_PLACEHOLDER, dc.getEndpoint().getService());
-      url[0] = url[0].replace(Constants.VERSION_PLACEHOLDER, dc.getEndpoint().getVersion());
-      url[0] = url[0].replace(Constants.RESOURCE_PLACEHOLDER, dc.getEndpoint().getResource());
-    }
-    if (dc.getPlatform() != null)
-    {
-      url[0] = url[0].replace(Constants.PLATFORM_PLACEHOLDER, dc.getPlatform().toString().toLowerCase());
-      url[0] = url[0].replace(Constants.REGION_PLACEHOLDER, ((RealmSpesificEnum) dc.getPlatform()).getRealmValue());
-    }
-    dc.getUrlParams().forEach((k, v) -> url[0] = url[0].replace(k, v));
-
-    boolean first = true;
-    for (Entry<String, String> pair : dc.getUrlData().entrySet())
-    {
-      char token = first ? '?' : '&';
-
-      if (first)
-      {
-        first = !first;
-      }
-
-      url[0] = url[0] + token + pair.getKey() + '=' + pair.getValue();
-    }
-
-    return url[0];
-  }
-
-
-  /**
-   * Sets the endpoint to make the call to
-   *
-   * @param endpoint the endpoint to make the call to
-   * @return this
-   */
-  public DataCallBuilder withEndpoint(final URLEndpoint endpoint)
-  {
-    this.dc.setEndpoint(endpoint);
-    return this;
-  }
-
-  /**
-   * enables ratelimiters for this call
-   *
-   * @param flag enabled or disabled
-   * @return this
-   */
-  public DataCallBuilder withLimiters(final boolean flag)
-  {
-    this.dc.setUseLimiters(flag);
-    return this;
-  }
-
-  /**
-   * Sets the headers to use with the call
-   *
-   * @param key   the header key
-   * @param value the header value
-   * @return this
-   */
-  public DataCallBuilder withHeader(final String key, final String value)
-  {
-    this.dc.getUrlHeaders().merge(key, value, MERGE);
-    return this;
-  }
-
-  /**
-   * Sets the data to send with the request if its a POST call
-   *
-   * @param data the data to send
-   * @return this
-   */
-  public DataCallBuilder withPostData(final String data)
-  {
-    this.postData = data;
-    return this;
-  }
-
-
-  /**
-   * The request-method on the call (usually GET or POST)
-   *
-   * @param method the request method
-   * @return this
-   */
-  public DataCallBuilder withRequestMethod(final String method)
-  {
-    this.requestMethod = method;
-    return this;
-  }
-
-  /**
-   * Set the platform to make this call to. (ie. EUW1)
-   *
-   * @param server the server to make the call to
-   * @return this
-   */
-  public DataCallBuilder withPlatform(final Enum server)
-  {
-    this.dc.setPlatform(server);
-    return this;
-  }
-
-  /**
-   * Replaces placeholders in the URL (ie. {region})
-   *
-   * @param key   The key to replace (ie. {region})
-   * @param value The data to replace it with (ie. EUW)
-   * @return this
-   */
-  public DataCallBuilder withURLDataAsSet(final String key, final String value)
-  {
-    this.dc.getUrlData().merge(key, (this.dc.getUrlData().get(key) != null) ? ("&" + key + "=" + value) : value, MERGE_AS_SET);
-    return this;
-  }
-
-
-  /**
-   * Adds parameters to the url (ie. ?api_key)
-   *
-   * @param key   the parameter to add (ie. api_key)
-   * @param value the value to add after the parameter (ie. 6fa459ea-ee8a-3ca4-894e-db77e160355e)
-   * @return this
-   */
-  public DataCallBuilder withQueryParameter(final String key, final String value)
-  {
-    this.dc.getUrlData().merge(key, value, MERGE);
-    return this;
-  }
-
-  /**
-   * Replaces placeholders in the URL (ie. {region})
-   *
-   * @param key   The key to replace (ie. {region})
-   * @param value The data to replace it with (ie. EUW)
-   * @return this
-   */
-  public DataCallBuilder withURLParameter(final String key, final String value)
-  {
-    this.dc.getUrlParams().merge(key, value, MERGE);
-    return this;
-  }
-
-  public DataCallBuilder withProxy(String proxy)
-  {
-    this.dc.setProxy(proxy);
-    return this;
-  }
+	private static final int NUMBER_OF_CALLS_ALLOWED_IN_ASYNC = 200;
+
+	private static final Logger logger = LoggerFactory.getLogger(DataCallBuilder.class);
+
+	private final DataCall dc = new DataCall();
+
+	private static final BiFunction<String, String, String> MERGE        = (o, n) -> o + "," + n;
+	private static final BiFunction<String, String, String> MERGE_AS_SET = (o, n) -> o + n;
+
+	private String requestMethod = "GET";
+	private String postData      = "";
+
+	private Semaphore semaphore = new Semaphore(NUMBER_OF_CALLS_ALLOWED_IN_ASYNC, true);
+
+	private static final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager()
+	{
+		public java.security.cert.X509Certificate[] getAcceptedIssuers()
+		{
+			return null;
+		}
+
+		public void checkClientTrusted(X509Certificate[] certs, String authType)
+		{
+		}
+
+		public void checkServerTrusted(X509Certificate[] certs, String authType)
+		{
+		}
+	}
+	};
+
+	// Create all-trusting host name verifier
+	private static final HostnameVerifier allHostsValid = (hostname, session) -> true;
+
+	static
+	{
+		try
+		{
+			// Install the all-trusting trust manager
+			SSLContext sc = SSLContext.getInstance("SSL");
+			sc.init(null, trustAllCerts, new java.security.SecureRandom());
+			HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+		} catch (KeyManagementException | NoSuchAlgorithmException e)
+		{
+			e.printStackTrace();
+		}
+	}
+
+
+	private static void updateRatelimiter(Enum server, Enum endpoint)
+	{
+		RateLimiter limiter = DataCall.getLimiter().get(server).get(endpoint);
+		limiter.updatePermitsTakenPerX(DataCall.getCallData().get(server).get(endpoint));
+	}
+
+	private static final Map<URLEndpoint, AtomicLong> requestCount = new HashMap<>();
+
+	/**
+	 * Puts together all the data, and then returns an object representing the JSON from the call
+	 *
+	 * @param retrys the amount of retries already done (should not be passed in!)
+	 * @return an object generated from the requested JSON
+	 */
+	public Object build(int... retrys)
+	{
+		final String url = this.getURL();
+
+		try {
+			semaphore.acquire();
+			if (this.dc.useRatelimiter())
+			{
+				if (DataCall.getCredentials() == null)
+				{
+					throw new APIUnsupportedActionException("No API Creds set!");
+				}
+
+				dc.getUrlHeaders().putIfAbsent("X-Riot-Token", DataCall.getCredentials().getLoLAPIKey());
+
+				// app limit
+				applyLimit(this.dc.getPlatform(), this.dc.getPlatform());
+				// method limit
+				applyLimit(this.dc.getPlatform(), this.dc.getEndpoint());
+			}
+
+
+			logger.info("Trying url: {}", url);
+
+			final DataCallResponse response = this.getResponse(url);
+			//logger.debug(response.toString());
+
+			switch (response.getResponseCode())
+			{
+			case 200:
+			case 201:
+			case 204:
+			{
+				String returnValue = response.getResponseData();
+
+				if (this.dc.shouldReturnRawResponse())
+				{
+					return returnValue;
+				}
+
+				if (this.dc.getEndpoint() != null)
+				{
+					final Class<?> returnType = this.dc.getEndpoint().getType();
+					returnValue = postProcess(returnValue);
+
+					return Utils.getGson().fromJson(returnValue, returnType);
+				} else
+				{
+					return returnValue;
+				}
+			}
+
+			case 400:
+			{
+				String reasonText = "Your api request is malformed!\n";
+				reasonText += url + "\n";
+				throw new APIResponseException(APIHTTPErrorReason.ERROR_400, reasonText + response.getResponseData());
+			}
+
+			case 401:
+			{
+
+				String reasonText = "The API denied your request!\n";
+				reasonText += "Your API key was not present in the request\n";
+				reasonText += "Make sure you have setup your APICredentials before doing a API call!\n";
+				throw new APIResponseException(APIHTTPErrorReason.ERROR_401, reasonText + response.getResponseData());
+			}
+
+			case 403:
+			{
+
+				String reasonText = "The API denied your request!\n";
+				reasonText += "Possible reasons:\n";
+				reasonText += " - Your API key is invalid\n";
+				reasonText += " - You just regenerated the key; wait a few seconds, then try again\n";
+				reasonText += " - You are trying to call a endpoint you dont have access to\n";
+				throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
+			}
+
+			case 404:
+			{
+				return new Pair<>(response.getResponseCode(), response.getResponseData());
+			}
+
+			case 405:
+			{
+				String reasonText = "The API was unable to handle your request due to the wrong HTTP method being used.\n";
+				throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
+			}
+			case 429:
+				if (response.getResponseData().startsWith(RateLimitType.LIMIT_UNDERLYING.getReason()) || response.getResponseData().startsWith(RateLimitType.LIMIT_SERVICE.getReason()))
+				{
+					return sleepAndRetry(retrys, response.getResponseCode());
+				} else
+				{
+					String error = response.getResponseData() + "429 ratelimit hit! " +
+							"Please do not restart your application to refresh the timer! " +
+							"This isn't supposed to happen unless you restarted your app before the last limit was hit!";
+
+					logger.error(error);
+
+				}
+
+				return this.build();
+
+			case 500:
+			case 502:
+			case 503:
+			case 504:
+			{
+				return sleepAndRetry(retrys, response.getResponseCode());
+			}
+
+			case 599:
+			{
+				throw new APIResponseException(APIHTTPErrorReason.ERROR_599, response.getResponseData());
+			}
+
+			default:
+			{
+				break;
+			}
+			}
+
+			System.err.println("UNHANDLED RESPONSE CODE!!!");
+			System.err.println("Response Code:" + response.getResponseCode());
+			System.err.println("Response Data:" + response.getResponseData());
+			throw new APINoValidResponseException(response.getResponseData());
+		} catch (InterruptedException e) {
+			logger.error("Semaphore was interrupted while trying to acquire a permit for the API call: {}", url, e);
+			Thread.currentThread().interrupt();
+			return null;
+		}finally {
+			semaphore.release();
+		}
+	}
+
+	private String postProcess(String returnValue)
+	{
+		final List<URLEndpoint> ddragon = Arrays.asList(URLEndpoint.DDRAGON_CHAMPION_MANY, URLEndpoint.DDRAGON_SUMMONER_SPELLS);
+		if (ddragon.contains(this.dc.getEndpoint()))
+		{
+			returnValue = postProcessDDragonMany(returnValue);
+		}
+
+		if (this.dc.getEndpoint() == URLEndpoint.DDRAGON_ITEMS || this.dc.getEndpoint() == URLEndpoint.DDRAGON_RUNES)
+		{
+			returnValue = postProcessDDragonAddId(returnValue);
+		}
+
+		final List<URLEndpoint> summonerEndpoints = Arrays.asList(
+				URLEndpoint.V4_SUMMONER_BY_ACCOUNT,
+				URLEndpoint.V4_SUMMONER_BY_ID,
+				URLEndpoint.V4_SUMMONER_BY_PUUID,
+				URLEndpoint.V1_TFT_SUMMONER_BY_ACCOUNT,
+				URLEndpoint.V1_TFT_SUMMONER_BY_ID,
+				URLEndpoint.V1_TFT_SUMMONER_BY_PUUID);
+		if (summonerEndpoints.contains(this.dc.getEndpoint()))
+		{
+			returnValue = postProcessSummoner(returnValue);
+		}
+
+		final List<URLEndpoint> apexEndpoints = Arrays.asList(URLEndpoint.V4_LEAGUE_MASTER, URLEndpoint.V4_LEAGUE_GRANDMASTER, URLEndpoint.V4_LEAGUE_CHALLENGER,
+				URLEndpoint.V1_TFT_LEAGUE_MASTER, URLEndpoint.V1_TFT_LEAGUE_GRANDMASTER, URLEndpoint.V1_TFT_LEAGUE_CHALLENGER);
+		if (apexEndpoints.contains(this.dc.getEndpoint()))
+		{
+			returnValue = postProcessApex(returnValue);
+		}
+
+		return returnValue;
+	}
+
+	private String postProcessApex(String returnValue)
+	{
+		JsonObject elem    = (JsonObject) JsonParser.parseString(returnValue);
+		JsonArray  entries = elem.getAsJsonArray("entries");
+		if (entries == null)
+		{
+			entries = new JsonArray();
+		}
+
+		entries.forEach(e -> {
+			JsonObject ob = (JsonObject) e;
+			ob.add("leagueId", elem.get("leagueId"));
+			ob.add("queueType", elem.get("queue"));
+			ob.add("tier", elem.get("tier"));
+		});
+
+		return Utils.getGson().toJson(elem);
+	}
+
+	private String postProcessDDragonMany(String returnValue)
+	{
+		JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
+		JsonObject parent = elem.getAsJsonObject("data");
+		for (String key : new HashSet<>(parent.keySet()))
+		{
+			JsonObject child = parent.getAsJsonObject(key);
+			String     id    = child.get("key").getAsString();
+			child.addProperty("key", key);
+			child.addProperty("id", id);
+			parent.add(id, child);
+			parent.remove(key);
+		}
+
+		return Utils.getGson().toJson(elem);
+	}
+
+	private String postProcessDDragonAddId(String returnValue)
+	{
+		JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
+		JsonObject parent = elem.getAsJsonObject("data");
+		for (String key : new HashSet<>(parent.keySet()))
+		{
+			JsonObject child = parent.getAsJsonObject(key);
+			try 
+			{
+				int keyAsInt = Integer.parseInt(key);
+				child.addProperty("id", keyAsInt);
+
+			}   catch(NumberFormatException e) 
+			{
+				parent.remove(key);
+				logger.warn("Item/Rune received without a valid Id ({}), item removed from the list", key);
+			}
+		}
+
+		return Utils.getGson().toJson(elem);
+	}
+
+	private String postProcessPerkPath(String returnValue)
+	{
+		JsonObject elem     = (JsonObject) JsonParser.parseString(returnValue);
+		String     pathName = elem.get("name").getAsString();
+		String     pathId   = elem.get("id").getAsString();
+
+		JsonArray slots = elem.getAsJsonArray("slots");
+		for (JsonElement slot : slots)
+		{
+			JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
+			for (JsonElement rune : runes)
+			{
+				JsonObject obj = (JsonObject) rune;
+				obj.addProperty("runePathName", pathName);
+				obj.addProperty("runePathId", pathId);
+			}
+		}
+
+		return Utils.getGson().toJson(elem);
+	}
+
+	private String postProcessPerkPaths(String returnValue)
+	{
+		JsonArray element = (JsonArray) JsonParser.parseString(returnValue);
+
+		for (JsonElement elem : element)
+		{
+			String pathName = elem.getAsJsonObject().get("name").getAsString();
+			String pathId   = elem.getAsJsonObject().get("id").getAsString();
+
+			JsonArray slots = elem.getAsJsonObject().getAsJsonArray("slots");
+			for (JsonElement slot : slots)
+			{
+				JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
+				for (JsonElement rune : runes)
+				{
+					JsonObject obj = (JsonObject) rune;
+					obj.addProperty("runePathName", pathName);
+					obj.addProperty("runePathId", pathId);
+				}
+			}
+		}
+
+		return Utils.getGson().toJson(element);
+	}
+
+	private String postProcessSummoner(String returnValue)
+	{
+		JsonObject element = (JsonObject) JsonParser.parseString(returnValue);
+		element.addProperty("platform", this.dc.getPlatform().toString());
+		return Utils.getGson().toJson(element);
+	}
+
+	private Object sleepAndRetry(int[] retrys, int errorCode)
+	{
+		try
+		{
+			int  attempts           = (retrys != null && retrys.length == 1) ? ++retrys[0] : 1;
+			long nextSleepDuration  = attempts * 500L;
+			long totalSleepDuration = 0;
+			for (int i = 1; i < attempts; i++)
+			{
+				totalSleepDuration += i * 500L;
+			}
+
+
+			String message = "";
+			if (errorCode == 429)
+			{
+				message = "Ratelimit reached too many times, waiting " + nextSleepDuration / 1000 + " seconds then retrying";
+			} else
+			{
+				message = "Server error (" + errorCode + ") , waiting " + nextSleepDuration / 1000 + " seconds then retrying";
+			}
+
+			logger.info(message);
+
+			if (totalSleepDuration > this.dc.getMaxSleep())
+			{
+				throw new APINoValidResponseException(String.format("API did not return a valid response in time. Total sleep time is over the max sleep value %s > %s...\n" +
+						"Try setting `DataCall.setDefaultMaxSleep(long)` to a larger number (default is 10000)",
+						(nextSleepDuration + totalSleepDuration), this.dc.getMaxSleep()));
+			}
+
+			Thread.sleep(nextSleepDuration);
+			return this.build(attempts);
+		} catch (InterruptedException e)
+		{
+			throw new APINoValidResponseException("Something interupted the API timeout;" + e.getMessage());
+		}
+	}
+
+	public static final ReentrantLock lock = new ReentrantLock();
+
+	private void applyLimit(Enum platform, Enum endpoint)
+	{
+		lock.lock();
+		try
+		{
+			Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
+
+			if (child.get(endpoint) == null)
+			{
+				loadLimiterFromCache(platform, endpoint, child);
+			}
+		} finally
+		{
+			lock.unlock();
+		}
+
+		RateLimiter limitr = DataCall.getLimiter().getOrDefault(platform, new HashMap<>()).get(endpoint);
+
+		if (limitr != null)
+		{
+			limitr.acquire();
+			storeLimiter(platform, endpoint);
+		}
+	}
+
+	private void storeLimiter(Enum platform, Enum endpoint)
+	{
+		RateLimiter limiter  = DataCall.getLimiter().get(platform).get(endpoint);
+		String      baseKey  = platform.toString() + "/" + endpoint.toString();
+		String      limitKey = "limits/" + baseKey;
+		String      firstKey = "first/" + baseKey;
+		String      callKey  = "call/" + baseKey;
+
+		DataCall.getRatelimiterCache().put(firstKey, Utils.getGson().toJson(limiter.getFirstCallInTime()));
+		DataCall.getRatelimiterCache().put(callKey, Utils.getGson().toJson(limiter.getCallCountInTime()));
+	}
+
+	private void loadLimiterFromCache(Enum platform, Enum endpoint, Map<Enum, RateLimiter> child)
+	{
+		String baseKey  = platform.toString() + "/" + endpoint.toString();
+		String limitKey = "limits/" + baseKey;
+		String firstKey = "first/" + baseKey;
+		String callKey  = "call/" + baseKey;
+
+		String lastLimit = DataCall.getRatelimiterCache().get(limitKey, null);
+		String lastFirst = DataCall.getRatelimiterCache().get(firstKey, null);
+		String lastKey   = DataCall.getRatelimiterCache().get(callKey, null);
+
+		if (lastLimit == null)
+		{
+			logger.debug("No instance of an old ratelimiter found");
+			return;
+		} else
+		{
+			logger.debug("Loading old ratelimiter data");
+		}
+
+		try
+		{
+			List<RateLimit>            knownLimits = Utils.getGson().fromJson(lastLimit, new TypeToken<List<RateLimit>>() {}.getType());
+			Map<RateLimit, AtomicLong> knownTime   = Utils.getGson().fromJson(lastFirst, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
+			Map<RateLimit, AtomicLong> knownCount  = Utils.getGson().fromJson(lastKey, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
+
+
+			RateLimiter newerLimit = new BurstRateLimiter(knownLimits);
+			newerLimit.setCallCountInTime(knownCount);
+			newerLimit.setFirstCallInTime(knownTime);
+
+			logger.debug("Loaded ratelimit for {}", endpoint);
+
+			child.put(endpoint, newerLimit);
+			DataCall.getLimiter().put(platform, child);
+		} catch (JsonSyntaxException s)
+		{
+			try
+			{
+				logger.debug("Old ratelimiter was of incompatible type, re-creating");
+				DataCall.getRatelimiterCache().clear();
+				DataCall.getRatelimiterCache().sync();
+			} catch (BackingStoreException e)
+			{
+				e.printStackTrace();
+			}
+		}
+	}
+
+
+	/**
+	 * Opens a connection to the URL, then reads the data into a Response.
+	 *
+	 * @param url the URL to call
+	 * @return a DataCallResponse with the data from the call
+	 * @throws APINoValidResponseException if the datacall failed in any fashion
+	 */
+	private DataCallResponse getResponse(final String url)
+	{
+		final StringBuilder data = new StringBuilder();
+		try
+		{
+			final HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
+
+			con.setUseCaches(false);
+			con.setDefaultUseCaches(false);
+			con.setRequestProperty("User-Agent", "R4J");
+			con.setRequestProperty("Accept-Charset", "ISO-8859-1,utf-8");
+			con.setRequestProperty("Accept-Language", "en-US");
+			con.setRequestProperty("Cache-Control", "no-store,max-age=0,no-cache");
+			con.setRequestProperty("Expires", "0");
+			con.setRequestProperty("Pragma", "no-cache");
+			con.setRequestProperty("Connection", "keep-alive");
+			con.setRequestProperty("Content-Type", "application/json");
+			con.setConnectTimeout(this.dc.getConnectTimeout());
+			con.setReadTimeout(this.dc.getReadTimeout());
+			this.dc.getUrlHeaders().forEach(con::setRequestProperty);
+
+			if (requestMethod.equalsIgnoreCase("PATCH"))
+			{
+				con.setRequestProperty("X-HTTP-Method-Override", "PATCH");
+				con.setRequestMethod("POST");
+			} else
+			{
+				con.setRequestMethod(requestMethod);
+			}
+
+			StringBuilder sb = new StringBuilder();
+			con.getRequestProperties().forEach((key, value) -> sb.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
+
+			String printMe = new StringBuilder("\n")
+					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Url", url)).append("\n")
+					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Method", con.getRequestMethod())).append("\n")
+					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "POST data", this.postData)).append("\n")
+					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Headers", "")).append("\n")
+					.append(sb).toString();
+
+			//logger.debug(printMe);
+
+
+			if (null != this.postData && !this.postData.isEmpty())
+			{
+				con.setDoOutput(true);
+				final DataOutputStream writer = new DataOutputStream(con.getOutputStream());
+				writer.writeBytes(this.postData);
+				writer.flush();
+				writer.close();
+			}
+
+			con.connect();
+
+			StringBuilder sb2 = new StringBuilder("\n");
+			con.getHeaderFields().forEach((key, value) -> sb2.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
+
+			String printMe2 = new StringBuilder("\n").append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Response Headers", ""))
+					.append(sb2)
+					.toString();
+			//logger.debug(printMe2);
+
+
+			String appA    = con.getHeaderField("X-App-Rate-Limit");
+			String appB    = con.getHeaderField("X-App-Rate-Limit-Count");
+			String methodA = con.getHeaderField("X-Method-Rate-Limit");
+			String methodB = con.getHeaderField("X-Method-Rate-Limit-Count");
+
+			if (appA == null)
+			{
+				logger.debug("Header 'X-App-Rate-Limit' missing from call: {} ", getURL());
+			} else
+			{
+				lock.lock();
+				createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
+				saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
+				lock.unlock();
+			}
+
+			if (methodA == null)
+			{
+				logger.debug("Header 'X-Method-Rate-Limit' missing from call: {}", getURL());
+			} else
+			{
+				lock.lock();
+				createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
+				saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
+				lock.unlock();
+			}
+
+			String deprecationHeader = con.getHeaderField("X-Riot-Deprecated");
+			if (deprecationHeader != null)
+			{
+				LocalDateTime timeout = LocalDateTime.ofEpochSecond(Long.parseLong(deprecationHeader) / 1000, 0, ZoneOffset.ofHours(-7));
+				logger.info("You are using a deprecated method, this method will stop working at: {}", timeout);
+			}
+
+			if (con.getResponseCode() == 429)
+			{
+				final RateLimitType limitType = RateLimitType.getBestMatch(con.getHeaderField("X-Rate-Limit-Type"));
+
+				StringBuilder valueList = new StringBuilder();
+				DataCall.getLimiter().get(dc.getPlatform()).forEach((key, value) -> {
+					valueList.append(key);
+					valueList.append("=");
+					valueList.append(value.getCallCountInTime());
+					valueList.append("\n");
+				});
+
+				String reasonString = String.format("%s%n%s", limitType.getReason(), valueList.toString().trim());
+				String reason       = String.format("%s%n", reasonString);
+
+				if (limitType == RateLimitType.LIMIT_METHOD)
+				{
+					RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getEndpoint());
+					limter.updateSleep(con.getHeaderField("Retry-After"));
+				}
+
+				if (limitType == RateLimitType.LIMIT_USER)
+				{
+
+					RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getPlatform());
+					limter.updateSleep(con.getHeaderField("Retry-After"));
+				}
+
+				return new DataCallResponse(con.getResponseCode(), reason);
+			}
+
+			if (con.getResponseCode() == 204)
+			{
+				return new DataCallResponse(con.getResponseCode(), "");
+			}
+
+			InputStream stream = (con.getResponseCode() <= 399) ? con.getInputStream() : con.getErrorStream();
+
+			if (stream == null)
+			{
+				return new DataCallResponse(con.getResponseCode(), "Unable to read stream!");
+			}
+
+			try (BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)))
+			{
+				br.lines().forEach(data::append);
+			}
+
+			con.disconnect();
+
+			return new DataCallResponse(con.getResponseCode(), data.toString());
+		} catch (final IOException e)
+		{
+			throw new APIResponseException(APIHTTPErrorReason.ERROR_599, APIHTTPErrorReason.ERROR_599.getReason());
+		}
+	}
+
+	private void createRatelimiterIfMissing(String methodA, Enum platform, Enum endpoint)
+	{
+		Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
+
+		RateLimiter oldLimit   = child.get(endpoint);
+		RateLimiter newerLimit = createLimiter(methodA);
+
+		if (!newerLimit.equals(oldLimit))
+		{
+			newerLimit.mergeFrom(oldLimit);
+			child.put(endpoint, newerLimit);
+
+			logger.debug("Updating Ratelimit For {}", endpoint);
+			logger.debug(newerLimit.getLimits().toString());
+		}
+
+		DataCall.getLimiter().put(platform, child);
+	}
+
+	private void saveHeaderRateLimit(String limitCount, Enum platform, Enum endpoint)
+	{
+		Map<Enum, Map<Integer, Integer>> parent = DataCall.getCallData().getOrDefault(platform, new HashMap<>());
+		Map<Integer, Integer>            child  = parent.getOrDefault(endpoint, new HashMap<>());
+
+		child.putAll(parseLimitFromHeader(limitCount));
+		parent.put(endpoint, child);
+		DataCall.getCallData().put(platform, parent);
+
+		updateRatelimiter(platform, endpoint);
+		storeLimiter(platform, endpoint);
+	}
+
+	private Map<Integer, Integer> parseLimitFromHeader(String headerValue)
+	{
+		final String[]        limits  = headerValue.split(",");
+		Map<Integer, Integer> timeout = new HashMap<>();
+		for (final String limitPair : limits)
+		{
+			final String[] limit = limitPair.split(":");
+			final Integer  call  = Integer.parseInt(limit[0]);
+			final Integer  time  = Integer.parseInt(limit[1]);
+			timeout.put(time, call);
+		}
+
+		return timeout;
+	}
+
+	public RateLimiter createLimiter(String limitCount)
+	{
+		Map<Integer, Integer> timeout = parseLimitFromHeader(limitCount);
+
+		List<RateLimit> limits = new ArrayList<>();
+		for (Entry<Integer, Integer> entry : timeout.entrySet())
+		{
+			limits.add(new RateLimit(entry.getValue(), entry.getKey(), TimeUnit.SECONDS));
+		}
+
+		return new BurstRateLimiter(limits);
+	}
+
+	/**
+	 * Generates the URL to use for the call.
+	 *
+	 * @return the URL to use for the call.
+	 */
+	private String getURL()
+	{
+		String[] url = {dc.getProxy()};
+		if (dc.getEndpoint() != null)
+		{
+			url[0] = url[0].replace(Constants.GAME_PLACEHOLDER, dc.getEndpoint().getGame());
+			url[0] = url[0].replace(Constants.SERVICE_PLACEHOLDER, dc.getEndpoint().getService());
+			url[0] = url[0].replace(Constants.VERSION_PLACEHOLDER, dc.getEndpoint().getVersion());
+			url[0] = url[0].replace(Constants.RESOURCE_PLACEHOLDER, dc.getEndpoint().getResource());
+		}
+		if (dc.getPlatform() != null)
+		{
+			url[0] = url[0].replace(Constants.PLATFORM_PLACEHOLDER, dc.getPlatform().toString().toLowerCase());
+			url[0] = url[0].replace(Constants.REGION_PLACEHOLDER, ((RealmSpesificEnum) dc.getPlatform()).getRealmValue());
+		}
+		dc.getUrlParams().forEach((k, v) -> url[0] = url[0].replace(k, v));
+
+		boolean first = true;
+		for (Entry<String, String> pair : dc.getUrlData().entrySet())
+		{
+			char token = first ? '?' : '&';
+
+			if (first)
+			{
+				first = !first;
+			}
+
+			url[0] = url[0] + token + pair.getKey() + '=' + pair.getValue();
+		}
+
+		return url[0];
+	}
+
+
+	/**
+	 * Sets the endpoint to make the call to
+	 *
+	 * @param endpoint the endpoint to make the call to
+	 * @return this
+	 */
+	public DataCallBuilder withEndpoint(final URLEndpoint endpoint)
+	{
+		this.dc.setEndpoint(endpoint);
+		return this;
+	}
+
+	/**
+	 * enables ratelimiters for this call
+	 *
+	 * @param flag enabled or disabled
+	 * @return this
+	 */
+	public DataCallBuilder withLimiters(final boolean flag)
+	{
+		this.dc.setUseLimiters(flag);
+		return this;
+	}
+
+	/**
+	 * Sets the headers to use with the call
+	 *
+	 * @param key   the header key
+	 * @param value the header value
+	 * @return this
+	 */
+	public DataCallBuilder withHeader(final String key, final String value)
+	{
+		this.dc.getUrlHeaders().merge(key, value, MERGE);
+		return this;
+	}
+
+	/**
+	 * Sets the data to send with the request if its a POST call
+	 *
+	 * @param data the data to send
+	 * @return this
+	 */
+	public DataCallBuilder withPostData(final String data)
+	{
+		this.postData = data;
+		return this;
+	}
+
+
+	/**
+	 * The request-method on the call (usually GET or POST)
+	 *
+	 * @param method the request method
+	 * @return this
+	 */
+	public DataCallBuilder withRequestMethod(final String method)
+	{
+		this.requestMethod = method;
+		return this;
+	}
+
+	/**
+	 * Set the platform to make this call to. (ie. EUW1)
+	 *
+	 * @param server the server to make the call to
+	 * @return this
+	 */
+	public DataCallBuilder withPlatform(final Enum server)
+	{
+		this.dc.setPlatform(server);
+		return this;
+	}
+
+	/**
+	 * Replaces placeholders in the URL (ie. {region})
+	 *
+	 * @param key   The key to replace (ie. {region})
+	 * @param value The data to replace it with (ie. EUW)
+	 * @return this
+	 */
+	public DataCallBuilder withURLDataAsSet(final String key, final String value)
+	{
+		this.dc.getUrlData().merge(key, (this.dc.getUrlData().get(key) != null) ? ("&" + key + "=" + value) : value, MERGE_AS_SET);
+		return this;
+	}
+
+
+	/**
+	 * Adds parameters to the url (ie. ?api_key)
+	 *
+	 * @param key   the parameter to add (ie. api_key)
+	 * @param value the value to add after the parameter (ie. 6fa459ea-ee8a-3ca4-894e-db77e160355e)
+	 * @return this
+	 */
+	public DataCallBuilder withQueryParameter(final String key, final String value)
+	{
+		this.dc.getUrlData().merge(key, value, MERGE);
+		return this;
+	}
+
+	/**
+	 * Replaces placeholders in the URL (ie. {region})
+	 *
+	 * @param key   The key to replace (ie. {region})
+	 * @param value The data to replace it with (ie. EUW)
+	 * @return this
+	 */
+	public DataCallBuilder withURLParameter(final String key, final String value)
+	{
+		this.dc.getUrlParams().merge(key, value, MERGE);
+		return this;
+	}
+
+	public DataCallBuilder withProxy(String proxy)
+	{
+		this.dc.setProxy(proxy);
+		return this;
+	}
 }

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -28,855 +28,858 @@ import java.util.prefs.BackingStoreException;
 @SuppressWarnings("rawtypes")
 public class DataCallBuilder
 {
-	private static final int NUMBER_OF_CALLS_ALLOWED_IN_ASYNC = 200;
-
-	private static final Logger logger = LoggerFactory.getLogger(DataCallBuilder.class);
-
-	private final DataCall dc = new DataCall();
-
-	private static final BiFunction<String, String, String> MERGE        = (o, n) -> o + "," + n;
-	private static final BiFunction<String, String, String> MERGE_AS_SET = (o, n) -> o + n;
-
-	private String requestMethod = "GET";
-	private String postData      = "";
-
-	private Semaphore semaphore = new Semaphore(NUMBER_OF_CALLS_ALLOWED_IN_ASYNC, true);
-
-	private static final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager()
-	{
-		public java.security.cert.X509Certificate[] getAcceptedIssuers()
-		{
-			return null;
-		}
-
-		public void checkClientTrusted(X509Certificate[] certs, String authType)
-		{
-		}
-
-		public void checkServerTrusted(X509Certificate[] certs, String authType)
-		{
-		}
-	}
-	};
-
-	// Create all-trusting host name verifier
-	private static final HostnameVerifier allHostsValid = (hostname, session) -> true;
-
-	static
-	{
-		try
-		{
-			// Install the all-trusting trust manager
-			SSLContext sc = SSLContext.getInstance("SSL");
-			sc.init(null, trustAllCerts, new java.security.SecureRandom());
-			HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-		} catch (KeyManagementException | NoSuchAlgorithmException e)
-		{
-			e.printStackTrace();
-		}
-	}
-
-
-	private static void updateRatelimiter(Enum server, Enum endpoint)
-	{
-		RateLimiter limiter = DataCall.getLimiter().get(server).get(endpoint);
-		limiter.updatePermitsTakenPerX(DataCall.getCallData().get(server).get(endpoint));
-	}
-
-	private static final Map<URLEndpoint, AtomicLong> requestCount = new HashMap<>();
-
-	/**
-	 * Puts together all the data, and then returns an object representing the JSON from the call
-	 *
-	 * @param retrys the amount of retries already done (should not be passed in!)
-	 * @return an object generated from the requested JSON
-	 */
-	public Object build(int... retrys)
-	{
-		final String url = this.getURL();
-
-		try {
-			semaphore.acquire();
-			if (this.dc.useRatelimiter())
-			{
-				if (DataCall.getCredentials() == null)
-				{
-					throw new APIUnsupportedActionException("No API Creds set!");
-				}
-
-				dc.getUrlHeaders().putIfAbsent("X-Riot-Token", DataCall.getCredentials().getLoLAPIKey());
-
-				// app limit
-				applyLimit(this.dc.getPlatform(), this.dc.getPlatform());
-				// method limit
-				applyLimit(this.dc.getPlatform(), this.dc.getEndpoint());
-			}
-		} catch (InterruptedException e) {
-			logger.error("Semaphore was interrupted while trying to acquire a permit for the API call: {}", url, e);
-			Thread.currentThread().interrupt();
-		}finally {
-			semaphore.release();
-		}
-
-		logger.info("Trying url: {}", url);
-
-		final DataCallResponse response = this.getResponse(url);
-		//logger.debug(response.toString());
-
-		switch (response.getResponseCode())
-		{
-		case 200:
-		case 201:
-		case 204:
-		{
-			String returnValue = response.getResponseData();
-
-			if (this.dc.shouldReturnRawResponse())
-			{
-				return returnValue;
-			}
-
-			if (this.dc.getEndpoint() != null)
-			{
-				final Class<?> returnType = this.dc.getEndpoint().getType();
-				returnValue = postProcess(returnValue);
-
-				return Utils.getGson().fromJson(returnValue, returnType);
-			} else
-			{
-				return returnValue;
-			}
-		}
-
-		case 400:
-		{
-			String reasonText = "Your api request is malformed!\n";
-			reasonText += url + "\n";
-			throw new APIResponseException(APIHTTPErrorReason.ERROR_400, reasonText + response.getResponseData());
-		}
-
-		case 401:
-		{
-
-			String reasonText = "The API denied your request!\n";
-			reasonText += "Your API key was not present in the request\n";
-			reasonText += "Make sure you have setup your APICredentials before doing a API call!\n";
-			throw new APIResponseException(APIHTTPErrorReason.ERROR_401, reasonText + response.getResponseData());
-		}
-
-		case 403:
-		{
-
-			String reasonText = "The API denied your request!\n";
-			reasonText += "Possible reasons:\n";
-			reasonText += " - Your API key is invalid\n";
-			reasonText += " - You just regenerated the key; wait a few seconds, then try again\n";
-			reasonText += " - You are trying to call a endpoint you dont have access to\n";
-			throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
-		}
-
-		case 404:
-		{
-			return new Pair<>(response.getResponseCode(), response.getResponseData());
-		}
-
-		case 405:
-		{
-			String reasonText = "The API was unable to handle your request due to the wrong HTTP method being used.\n";
-			throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
-		}
-		case 429:
-			if (response.getResponseData().startsWith(RateLimitType.LIMIT_UNDERLYING.getReason()) || response.getResponseData().startsWith(RateLimitType.LIMIT_SERVICE.getReason()))
-			{
-				return sleepAndRetry(retrys, response.getResponseCode());
-			} else
-			{
-				String error = response.getResponseData() + "429 ratelimit hit! " +
-						"Please do not restart your application to refresh the timer! " +
-						"This isn't supposed to happen unless you restarted your app before the last limit was hit!";
-
-				logger.error(error);
-
-			}
-
-			return this.build();
-
-		case 500:
-		case 502:
-		case 503:
-		case 504:
-		{
-			return sleepAndRetry(retrys, response.getResponseCode());
-		}
-
-		case 599:
-		{
-			throw new APIResponseException(APIHTTPErrorReason.ERROR_599, response.getResponseData());
-		}
-
-		default:
-		{
-			break;
-		}
-		}
-
-		System.err.println("UNHANDLED RESPONSE CODE!!!");
-		System.err.println("Response Code:" + response.getResponseCode());
-		System.err.println("Response Data:" + response.getResponseData());
-		throw new APINoValidResponseException(response.getResponseData());
-	}
-
-	private String postProcess(String returnValue)
-	{
-		final List<URLEndpoint> ddragon = Arrays.asList(URLEndpoint.DDRAGON_CHAMPION_MANY, URLEndpoint.DDRAGON_SUMMONER_SPELLS);
-		if (ddragon.contains(this.dc.getEndpoint()))
-		{
-			returnValue = postProcessDDragonMany(returnValue);
-		}
-
-		if (this.dc.getEndpoint() == URLEndpoint.DDRAGON_ITEMS || this.dc.getEndpoint() == URLEndpoint.DDRAGON_RUNES)
-		{
-			returnValue = postProcessDDragonAddId(returnValue);
-		}
-
-		final List<URLEndpoint> summonerEndpoints = Arrays.asList(
-				URLEndpoint.V4_SUMMONER_BY_ACCOUNT,
-				URLEndpoint.V4_SUMMONER_BY_ID,
-				URLEndpoint.V4_SUMMONER_BY_PUUID,
-				URLEndpoint.V1_TFT_SUMMONER_BY_ACCOUNT,
-				URLEndpoint.V1_TFT_SUMMONER_BY_ID,
-				URLEndpoint.V1_TFT_SUMMONER_BY_PUUID);
-		if (summonerEndpoints.contains(this.dc.getEndpoint()))
-		{
-			returnValue = postProcessSummoner(returnValue);
-		}
-
-		final List<URLEndpoint> apexEndpoints = Arrays.asList(URLEndpoint.V4_LEAGUE_MASTER, URLEndpoint.V4_LEAGUE_GRANDMASTER, URLEndpoint.V4_LEAGUE_CHALLENGER,
-				URLEndpoint.V1_TFT_LEAGUE_MASTER, URLEndpoint.V1_TFT_LEAGUE_GRANDMASTER, URLEndpoint.V1_TFT_LEAGUE_CHALLENGER);
-		if (apexEndpoints.contains(this.dc.getEndpoint()))
-		{
-			returnValue = postProcessApex(returnValue);
-		}
-
-		return returnValue;
-	}
-
-	private String postProcessApex(String returnValue)
-	{
-		JsonObject elem    = (JsonObject) JsonParser.parseString(returnValue);
-		JsonArray  entries = elem.getAsJsonArray("entries");
-		if (entries == null)
-		{
-			entries = new JsonArray();
-		}
-
-		entries.forEach(e -> {
-			JsonObject ob = (JsonObject) e;
-			ob.add("leagueId", elem.get("leagueId"));
-			ob.add("queueType", elem.get("queue"));
-			ob.add("tier", elem.get("tier"));
-		});
-
-		return Utils.getGson().toJson(elem);
-	}
-
-	private String postProcessDDragonMany(String returnValue)
-	{
-		JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
-		JsonObject parent = elem.getAsJsonObject("data");
-		for (String key : new HashSet<>(parent.keySet()))
-		{
-			JsonObject child = parent.getAsJsonObject(key);
-			String     id    = child.get("key").getAsString();
-			child.addProperty("key", key);
-			child.addProperty("id", id);
-			parent.add(id, child);
-			parent.remove(key);
-		}
-
-		return Utils.getGson().toJson(elem);
-	}
-
-	private String postProcessDDragonAddId(String returnValue)
-	{
-		JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
-		JsonObject parent = elem.getAsJsonObject("data");
-		for (String key : new HashSet<>(parent.keySet()))
-		{
-			JsonObject child = parent.getAsJsonObject(key);
-			try 
-			{
-				int keyAsInt = Integer.parseInt(key);
-				child.addProperty("id", keyAsInt);
-
-			}   catch(NumberFormatException e) 
-			{
-				parent.remove(key);
-				logger.warn("Item/Rune received without a valid Id ({}), item removed from the list", key);
-			}
-		}
-
-		return Utils.getGson().toJson(elem);
-	}
-
-	private String postProcessPerkPath(String returnValue)
-	{
-		JsonObject elem     = (JsonObject) JsonParser.parseString(returnValue);
-		String     pathName = elem.get("name").getAsString();
-		String     pathId   = elem.get("id").getAsString();
-
-		JsonArray slots = elem.getAsJsonArray("slots");
-		for (JsonElement slot : slots)
-		{
-			JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
-			for (JsonElement rune : runes)
-			{
-				JsonObject obj = (JsonObject) rune;
-				obj.addProperty("runePathName", pathName);
-				obj.addProperty("runePathId", pathId);
-			}
-		}
-
-		return Utils.getGson().toJson(elem);
-	}
-
-	private String postProcessPerkPaths(String returnValue)
-	{
-		JsonArray element = (JsonArray) JsonParser.parseString(returnValue);
-
-		for (JsonElement elem : element)
-		{
-			String pathName = elem.getAsJsonObject().get("name").getAsString();
-			String pathId   = elem.getAsJsonObject().get("id").getAsString();
-
-			JsonArray slots = elem.getAsJsonObject().getAsJsonArray("slots");
-			for (JsonElement slot : slots)
-			{
-				JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
-				for (JsonElement rune : runes)
-				{
-					JsonObject obj = (JsonObject) rune;
-					obj.addProperty("runePathName", pathName);
-					obj.addProperty("runePathId", pathId);
-				}
-			}
-		}
-
-		return Utils.getGson().toJson(element);
-	}
-
-	private String postProcessSummoner(String returnValue)
-	{
-		JsonObject element = (JsonObject) JsonParser.parseString(returnValue);
-		element.addProperty("platform", this.dc.getPlatform().toString());
-		return Utils.getGson().toJson(element);
-	}
-
-	private Object sleepAndRetry(int[] retrys, int errorCode)
-	{
-		try
-		{
-			int  attempts           = (retrys != null && retrys.length == 1) ? ++retrys[0] : 1;
-			long nextSleepDuration  = attempts * 500L;
-			long totalSleepDuration = 0;
-			for (int i = 1; i < attempts; i++)
-			{
-				totalSleepDuration += i * 500L;
-			}
-
-
-			String message = "";
-			if (errorCode == 429)
-			{
-				message = "Ratelimit reached too many times, waiting " + nextSleepDuration / 1000 + " seconds then retrying";
-			} else
-			{
-				message = "Server error (" + errorCode + ") , waiting " + nextSleepDuration / 1000 + " seconds then retrying";
-			}
-
-			logger.info(message);
-
-			if (totalSleepDuration > this.dc.getMaxSleep())
-			{
-				throw new APINoValidResponseException(String.format("API did not return a valid response in time. Total sleep time is over the max sleep value %s > %s...\n" +
-						"Try setting `DataCall.setDefaultMaxSleep(long)` to a larger number (default is 10000)",
-						(nextSleepDuration + totalSleepDuration), this.dc.getMaxSleep()));
-			}
-
-			Thread.sleep(nextSleepDuration);
-			return this.build(attempts);
-		} catch (InterruptedException e)
-		{
-			throw new APINoValidResponseException("Something interupted the API timeout;" + e.getMessage());
-		}
-	}
-
-	public static final ReentrantLock lock = new ReentrantLock();
-
-	private void applyLimit(Enum platform, Enum endpoint)
-	{
-		lock.lock();
-		try
-		{
-			Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
-
-			if (child.get(endpoint) == null)
-			{
-				loadLimiterFromCache(platform, endpoint, child);
-			}
-		} finally
-		{
-			lock.unlock();
-		}
-
-		RateLimiter limitr = DataCall.getLimiter().getOrDefault(platform, new HashMap<>()).get(endpoint);
-
-		if (limitr != null)
-		{
-			limitr.acquire();
-			storeLimiter(platform, endpoint);
-		}
-	}
-
-	private void storeLimiter(Enum platform, Enum endpoint)
-	{
-		RateLimiter limiter  = DataCall.getLimiter().get(platform).get(endpoint);
-		String      baseKey  = platform.toString() + "/" + endpoint.toString();
-		String      limitKey = "limits/" + baseKey;
-		String      firstKey = "first/" + baseKey;
-		String      callKey  = "call/" + baseKey;
-
-		DataCall.getRatelimiterCache().put(firstKey, Utils.getGson().toJson(limiter.getFirstCallInTime()));
-		DataCall.getRatelimiterCache().put(callKey, Utils.getGson().toJson(limiter.getCallCountInTime()));
-	}
-
-	private void loadLimiterFromCache(Enum platform, Enum endpoint, Map<Enum, RateLimiter> child)
-	{
-		String baseKey  = platform.toString() + "/" + endpoint.toString();
-		String limitKey = "limits/" + baseKey;
-		String firstKey = "first/" + baseKey;
-		String callKey  = "call/" + baseKey;
-
-		String lastLimit = DataCall.getRatelimiterCache().get(limitKey, null);
-		String lastFirst = DataCall.getRatelimiterCache().get(firstKey, null);
-		String lastKey   = DataCall.getRatelimiterCache().get(callKey, null);
-
-		if (lastLimit == null)
-		{
-			logger.debug("No instance of an old ratelimiter found");
-			return;
-		} else
-		{
-			logger.debug("Loading old ratelimiter data");
-		}
-
-		try
-		{
-			List<RateLimit>            knownLimits = Utils.getGson().fromJson(lastLimit, new TypeToken<List<RateLimit>>() {}.getType());
-			Map<RateLimit, AtomicLong> knownTime   = Utils.getGson().fromJson(lastFirst, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
-			Map<RateLimit, AtomicLong> knownCount  = Utils.getGson().fromJson(lastKey, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
-
-
-			RateLimiter newerLimit = new BurstRateLimiter(knownLimits);
-			newerLimit.setCallCountInTime(knownCount);
-			newerLimit.setFirstCallInTime(knownTime);
-
-			logger.debug("Loaded ratelimit for {}", endpoint);
-
-			child.put(endpoint, newerLimit);
-			DataCall.getLimiter().put(platform, child);
-		} catch (JsonSyntaxException s)
-		{
-			try
-			{
-				logger.debug("Old ratelimiter was of incompatible type, re-creating");
-				DataCall.getRatelimiterCache().clear();
-				DataCall.getRatelimiterCache().sync();
-			} catch (BackingStoreException e)
-			{
-				e.printStackTrace();
-			}
-		}
-	}
-
-
-	/**
-	 * Opens a connection to the URL, then reads the data into a Response.
-	 *
-	 * @param url the URL to call
-	 * @return a DataCallResponse with the data from the call
-	 * @throws APINoValidResponseException if the datacall failed in any fashion
-	 */
-	private DataCallResponse getResponse(final String url)
-	{
-		final StringBuilder data = new StringBuilder();
-		try
-		{
-			final HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
-
-			con.setUseCaches(false);
-			con.setDefaultUseCaches(false);
-			con.setRequestProperty("User-Agent", "R4J");
-			con.setRequestProperty("Accept-Charset", "ISO-8859-1,utf-8");
-			con.setRequestProperty("Accept-Language", "en-US");
-			con.setRequestProperty("Cache-Control", "no-store,max-age=0,no-cache");
-			con.setRequestProperty("Expires", "0");
-			con.setRequestProperty("Pragma", "no-cache");
-			con.setRequestProperty("Connection", "keep-alive");
-			con.setRequestProperty("Content-Type", "application/json");
-			con.setConnectTimeout(this.dc.getConnectTimeout());
-			con.setReadTimeout(this.dc.getReadTimeout());
-			this.dc.getUrlHeaders().forEach(con::setRequestProperty);
-
-			if (requestMethod.equalsIgnoreCase("PATCH"))
-			{
-				con.setRequestProperty("X-HTTP-Method-Override", "PATCH");
-				con.setRequestMethod("POST");
-			} else
-			{
-				con.setRequestMethod(requestMethod);
-			}
-
-			StringBuilder sb = new StringBuilder();
-			con.getRequestProperties().forEach((key, value) -> sb.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
-
-			String printMe = new StringBuilder("\n")
-					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Url", url)).append("\n")
-					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Method", con.getRequestMethod())).append("\n")
-					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "POST data", this.postData)).append("\n")
-					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Headers", "")).append("\n")
-					.append(sb).toString();
-
-			//logger.debug(printMe);
-
-
-			if (null != this.postData && !this.postData.isEmpty())
-			{
-				con.setDoOutput(true);
-				final DataOutputStream writer = new DataOutputStream(con.getOutputStream());
-				writer.writeBytes(this.postData);
-				writer.flush();
-				writer.close();
-			}
-
-			con.connect();
-
-			StringBuilder sb2 = new StringBuilder("\n");
-			con.getHeaderFields().forEach((key, value) -> sb2.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
-
-			String printMe2 = new StringBuilder("\n").append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Response Headers", ""))
-					.append(sb2)
-					.toString();
-			//logger.debug(printMe2);
-
-
-			String appA    = con.getHeaderField("X-App-Rate-Limit");
-			String appB    = con.getHeaderField("X-App-Rate-Limit-Count");
-			String methodA = con.getHeaderField("X-Method-Rate-Limit");
-			String methodB = con.getHeaderField("X-Method-Rate-Limit-Count");
-
-			if (appA == null)
-			{
-				logger.debug("Header 'X-App-Rate-Limit' missing from call: {} ", getURL());
-			} else
-			{
-				lock.lock();
-				createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
-				saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
-				lock.unlock();
-			}
-
-			if (methodA == null)
-			{
-				logger.debug("Header 'X-Method-Rate-Limit' missing from call: {}", getURL());
-			} else
-			{
-				lock.lock();
-				createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
-				saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
-				lock.unlock();
-			}
-
-			String deprecationHeader = con.getHeaderField("X-Riot-Deprecated");
-			if (deprecationHeader != null)
-			{
-				LocalDateTime timeout = LocalDateTime.ofEpochSecond(Long.parseLong(deprecationHeader) / 1000, 0, ZoneOffset.ofHours(-7));
-				logger.info("You are using a deprecated method, this method will stop working at: {}", timeout);
-			}
-
-			if (con.getResponseCode() == 429)
-			{
-				final RateLimitType limitType = RateLimitType.getBestMatch(con.getHeaderField("X-Rate-Limit-Type"));
-
-				StringBuilder valueList = new StringBuilder();
-				DataCall.getLimiter().get(dc.getPlatform()).forEach((key, value) -> {
-					valueList.append(key);
-					valueList.append("=");
-					valueList.append(value.getCallCountInTime());
-					valueList.append("\n");
-				});
-
-				String reasonString = String.format("%s%n%s", limitType.getReason(), valueList.toString().trim());
-				String reason       = String.format("%s%n", reasonString);
-
-				if (limitType == RateLimitType.LIMIT_METHOD)
-				{
-					RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getEndpoint());
-					limter.updateSleep(con.getHeaderField("Retry-After"));
-				}
-
-				if (limitType == RateLimitType.LIMIT_USER)
-				{
-
-					RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getPlatform());
-					limter.updateSleep(con.getHeaderField("Retry-After"));
-				}
-
-				return new DataCallResponse(con.getResponseCode(), reason);
-			}
-
-			if (con.getResponseCode() == 204)
-			{
-				return new DataCallResponse(con.getResponseCode(), "");
-			}
-
-			InputStream stream = (con.getResponseCode() <= 399) ? con.getInputStream() : con.getErrorStream();
-
-			if (stream == null)
-			{
-				return new DataCallResponse(con.getResponseCode(), "Unable to read stream!");
-			}
-
-			try (BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)))
-			{
-				br.lines().forEach(data::append);
-			}
-
-			con.disconnect();
-
-			return new DataCallResponse(con.getResponseCode(), data.toString());
-		} catch (final IOException e)
-		{
-			throw new APIResponseException(APIHTTPErrorReason.ERROR_599, APIHTTPErrorReason.ERROR_599.getReason());
-		}
-	}
-
-	private void createRatelimiterIfMissing(String methodA, Enum platform, Enum endpoint)
-	{
-		Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
-
-		RateLimiter oldLimit   = child.get(endpoint);
-		RateLimiter newerLimit = createLimiter(methodA);
-
-		if (!newerLimit.equals(oldLimit))
-		{
-			newerLimit.mergeFrom(oldLimit);
-			child.put(endpoint, newerLimit);
-
-			logger.debug("Updating Ratelimit For {}", endpoint);
-			logger.debug(newerLimit.getLimits().toString());
-		}
-
-		DataCall.getLimiter().put(platform, child);
-	}
-
-	private void saveHeaderRateLimit(String limitCount, Enum platform, Enum endpoint)
-	{
-		Map<Enum, Map<Integer, Integer>> parent = DataCall.getCallData().getOrDefault(platform, new HashMap<>());
-		Map<Integer, Integer>            child  = parent.getOrDefault(endpoint, new HashMap<>());
-
-		child.putAll(parseLimitFromHeader(limitCount));
-		parent.put(endpoint, child);
-		DataCall.getCallData().put(platform, parent);
-
-		updateRatelimiter(platform, endpoint);
-		storeLimiter(platform, endpoint);
-	}
-
-	private Map<Integer, Integer> parseLimitFromHeader(String headerValue)
-	{
-		final String[]        limits  = headerValue.split(",");
-		Map<Integer, Integer> timeout = new HashMap<>();
-		for (final String limitPair : limits)
-		{
-			final String[] limit = limitPair.split(":");
-			final Integer  call  = Integer.parseInt(limit[0]);
-			final Integer  time  = Integer.parseInt(limit[1]);
-			timeout.put(time, call);
-		}
-
-		return timeout;
-	}
-
-	public RateLimiter createLimiter(String limitCount)
-	{
-		Map<Integer, Integer> timeout = parseLimitFromHeader(limitCount);
-
-		List<RateLimit> limits = new ArrayList<>();
-		for (Entry<Integer, Integer> entry : timeout.entrySet())
-		{
-			limits.add(new RateLimit(entry.getValue(), entry.getKey(), TimeUnit.SECONDS));
-		}
-
-		return new BurstRateLimiter(limits);
-	}
-
-	/**
-	 * Generates the URL to use for the call.
-	 *
-	 * @return the URL to use for the call.
-	 */
-	private String getURL()
-	{
-		String[] url = {dc.getProxy()};
-		if (dc.getEndpoint() != null)
-		{
-			url[0] = url[0].replace(Constants.GAME_PLACEHOLDER, dc.getEndpoint().getGame());
-			url[0] = url[0].replace(Constants.SERVICE_PLACEHOLDER, dc.getEndpoint().getService());
-			url[0] = url[0].replace(Constants.VERSION_PLACEHOLDER, dc.getEndpoint().getVersion());
-			url[0] = url[0].replace(Constants.RESOURCE_PLACEHOLDER, dc.getEndpoint().getResource());
-		}
-		if (dc.getPlatform() != null)
-		{
-			url[0] = url[0].replace(Constants.PLATFORM_PLACEHOLDER, dc.getPlatform().toString().toLowerCase());
-			url[0] = url[0].replace(Constants.REGION_PLACEHOLDER, ((RealmSpesificEnum) dc.getPlatform()).getRealmValue());
-		}
-		dc.getUrlParams().forEach((k, v) -> url[0] = url[0].replace(k, v));
-
-		boolean first = true;
-		for (Entry<String, String> pair : dc.getUrlData().entrySet())
-		{
-			char token = first ? '?' : '&';
-
-			if (first)
-			{
-				first = !first;
-			}
-
-			url[0] = url[0] + token + pair.getKey() + '=' + pair.getValue();
-		}
-
-		return url[0];
-	}
-
-
-	/**
-	 * Sets the endpoint to make the call to
-	 *
-	 * @param endpoint the endpoint to make the call to
-	 * @return this
-	 */
-	public DataCallBuilder withEndpoint(final URLEndpoint endpoint)
-	{
-		this.dc.setEndpoint(endpoint);
-		return this;
-	}
-
-	/**
-	 * enables ratelimiters for this call
-	 *
-	 * @param flag enabled or disabled
-	 * @return this
-	 */
-	public DataCallBuilder withLimiters(final boolean flag)
-	{
-		this.dc.setUseLimiters(flag);
-		return this;
-	}
-
-	/**
-	 * Sets the headers to use with the call
-	 *
-	 * @param key   the header key
-	 * @param value the header value
-	 * @return this
-	 */
-	public DataCallBuilder withHeader(final String key, final String value)
-	{
-		this.dc.getUrlHeaders().merge(key, value, MERGE);
-		return this;
-	}
-
-	/**
-	 * Sets the data to send with the request if its a POST call
-	 *
-	 * @param data the data to send
-	 * @return this
-	 */
-	public DataCallBuilder withPostData(final String data)
-	{
-		this.postData = data;
-		return this;
-	}
-
-
-	/**
-	 * The request-method on the call (usually GET or POST)
-	 *
-	 * @param method the request method
-	 * @return this
-	 */
-	public DataCallBuilder withRequestMethod(final String method)
-	{
-		this.requestMethod = method;
-		return this;
-	}
-
-	/**
-	 * Set the platform to make this call to. (ie. EUW1)
-	 *
-	 * @param server the server to make the call to
-	 * @return this
-	 */
-	public DataCallBuilder withPlatform(final Enum server)
-	{
-		this.dc.setPlatform(server);
-		return this;
-	}
-
-	/**
-	 * Replaces placeholders in the URL (ie. {region})
-	 *
-	 * @param key   The key to replace (ie. {region})
-	 * @param value The data to replace it with (ie. EUW)
-	 * @return this
-	 */
-	public DataCallBuilder withURLDataAsSet(final String key, final String value)
-	{
-		this.dc.getUrlData().merge(key, (this.dc.getUrlData().get(key) != null) ? ("&" + key + "=" + value) : value, MERGE_AS_SET);
-		return this;
-	}
-
-
-	/**
-	 * Adds parameters to the url (ie. ?api_key)
-	 *
-	 * @param key   the parameter to add (ie. api_key)
-	 * @param value the value to add after the parameter (ie. 6fa459ea-ee8a-3ca4-894e-db77e160355e)
-	 * @return this
-	 */
-	public DataCallBuilder withQueryParameter(final String key, final String value)
-	{
-		this.dc.getUrlData().merge(key, value, MERGE);
-		return this;
-	}
-
-	/**
-	 * Replaces placeholders in the URL (ie. {region})
-	 *
-	 * @param key   The key to replace (ie. {region})
-	 * @param value The data to replace it with (ie. EUW)
-	 * @return this
-	 */
-	public DataCallBuilder withURLParameter(final String key, final String value)
-	{
-		this.dc.getUrlParams().merge(key, value, MERGE);
-		return this;
-	}
-
-	public DataCallBuilder withProxy(String proxy)
-	{
-		this.dc.setProxy(proxy);
-		return this;
-	}
+  private static final int NUMBER_OF_CALLS_ALLOWED_IN_ASYNC = 200;
+
+  private static final Logger logger = LoggerFactory.getLogger(DataCallBuilder.class);
+
+  private final DataCall dc = new DataCall();
+
+  private static final BiFunction<String, String, String> MERGE        = (o, n) -> o + "," + n;
+  private static final BiFunction<String, String, String> MERGE_AS_SET = (o, n) -> o + n;
+
+  private String requestMethod = "GET";
+  private String postData      = "";
+
+  private Semaphore semaphore = new Semaphore(NUMBER_OF_CALLS_ALLOWED_IN_ASYNC, true);
+
+  private static final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager()
+  {
+    public java.security.cert.X509Certificate[] getAcceptedIssuers()
+    {
+      return null;
+    }
+
+    public void checkClientTrusted(X509Certificate[] certs, String authType)
+    {
+    }
+
+    public void checkServerTrusted(X509Certificate[] certs, String authType)
+    {
+    }
+  }
+  };
+
+  // Create all-trusting host name verifier
+  private static final HostnameVerifier allHostsValid = (hostname, session) -> true;
+
+  static
+  {
+    try
+    {
+      // Install the all-trusting trust manager
+      SSLContext sc = SSLContext.getInstance("SSL");
+      sc.init(null, trustAllCerts, new java.security.SecureRandom());
+      HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+    } catch (KeyManagementException | NoSuchAlgorithmException e)
+    {
+      e.printStackTrace();
+    }
+  }
+
+
+  private static void updateRatelimiter(Enum server, Enum endpoint)
+  {
+    RateLimiter limiter = DataCall.getLimiter().get(server).get(endpoint);
+    limiter.updatePermitsTakenPerX(DataCall.getCallData().get(server).get(endpoint));
+  }
+
+  private static final Map<URLEndpoint, AtomicLong> requestCount = new HashMap<>();
+
+  /**
+   * Puts together all the data, and then returns an object representing the JSON from the call
+   *
+   * @param retrys the amount of retries already done (should not be passed in!)
+   * @return an object generated from the requested JSON
+   */
+  public Object build(int... retrys)
+  {
+    final String url = this.getURL();
+
+    try {
+      semaphore.acquire();
+      if (this.dc.useRatelimiter())
+      {
+        if (DataCall.getCredentials() == null)
+        {
+          throw new APIUnsupportedActionException("No API Creds set!");
+        }
+
+        dc.getUrlHeaders().putIfAbsent("X-Riot-Token", DataCall.getCredentials().getLoLAPIKey());
+
+        // app limit
+        applyLimit(this.dc.getPlatform(), this.dc.getPlatform());
+        // method limit
+        applyLimit(this.dc.getPlatform(), this.dc.getEndpoint());
+      }
+
+
+      logger.info("Trying url: {}", url);
+
+      final DataCallResponse response = this.getResponse(url);
+      //logger.debug(response.toString());
+
+      switch (response.getResponseCode())
+      {
+      case 200:
+      case 201:
+      case 204:
+      {
+        String returnValue = response.getResponseData();
+
+        if (this.dc.shouldReturnRawResponse())
+        {
+          return returnValue;
+        }
+
+        if (this.dc.getEndpoint() != null)
+        {
+          final Class<?> returnType = this.dc.getEndpoint().getType();
+          returnValue = postProcess(returnValue);
+
+          return Utils.getGson().fromJson(returnValue, returnType);
+        } else
+        {
+          return returnValue;
+        }
+      }
+
+      case 400:
+      {
+        String reasonText = "Your api request is malformed!\n";
+        reasonText += url + "\n";
+        throw new APIResponseException(APIHTTPErrorReason.ERROR_400, reasonText + response.getResponseData());
+      }
+
+      case 401:
+      {
+
+        String reasonText = "The API denied your request!\n";
+        reasonText += "Your API key was not present in the request\n";
+        reasonText += "Make sure you have setup your APICredentials before doing a API call!\n";
+        throw new APIResponseException(APIHTTPErrorReason.ERROR_401, reasonText + response.getResponseData());
+      }
+
+      case 403:
+      {
+
+        String reasonText = "The API denied your request!\n";
+        reasonText += "Possible reasons:\n";
+        reasonText += " - Your API key is invalid\n";
+        reasonText += " - You just regenerated the key; wait a few seconds, then try again\n";
+        reasonText += " - You are trying to call a endpoint you dont have access to\n";
+        throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
+      }
+
+      case 404:
+      {
+        return new Pair<>(response.getResponseCode(), response.getResponseData());
+      }
+
+      case 405:
+      {
+        String reasonText = "The API was unable to handle your request due to the wrong HTTP method being used.\n";
+        throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
+      }
+      case 429:
+        if (response.getResponseData().startsWith(RateLimitType.LIMIT_UNDERLYING.getReason()) || response.getResponseData().startsWith(RateLimitType.LIMIT_SERVICE.getReason()))
+        {
+          return sleepAndRetry(retrys, response.getResponseCode());
+        } else
+        {
+          String error = response.getResponseData() + "429 ratelimit hit! " +
+              "Please do not restart your application to refresh the timer! " +
+              "This isn't supposed to happen unless you restarted your app before the last limit was hit!";
+
+          logger.error(error);
+
+        }
+
+        return this.build();
+
+      case 500:
+      case 502:
+      case 503:
+      case 504:
+      {
+        return sleepAndRetry(retrys, response.getResponseCode());
+      }
+
+      case 599:
+      {
+        throw new APIResponseException(APIHTTPErrorReason.ERROR_599, response.getResponseData());
+      }
+
+      default:
+      {
+        break;
+      }
+      }
+
+      System.err.println("UNHANDLED RESPONSE CODE!!!");
+      System.err.println("Response Code:" + response.getResponseCode());
+      System.err.println("Response Data:" + response.getResponseData());
+      throw new APINoValidResponseException(response.getResponseData());
+    } catch (InterruptedException e) {
+      logger.error("Semaphore was interrupted while trying to acquire a permit for the API call: {}", url, e);
+      Thread.currentThread().interrupt();
+      return null;
+    }finally {
+      semaphore.release();
+    }
+  }
+
+  private String postProcess(String returnValue)
+  {
+    final List<URLEndpoint> ddragon = Arrays.asList(URLEndpoint.DDRAGON_CHAMPION_MANY, URLEndpoint.DDRAGON_SUMMONER_SPELLS);
+    if (ddragon.contains(this.dc.getEndpoint()))
+    {
+      returnValue = postProcessDDragonMany(returnValue);
+    }
+
+    if (this.dc.getEndpoint() == URLEndpoint.DDRAGON_ITEMS || this.dc.getEndpoint() == URLEndpoint.DDRAGON_RUNES)
+    {
+      returnValue = postProcessDDragonAddId(returnValue);
+    }
+
+    final List<URLEndpoint> summonerEndpoints = Arrays.asList(
+        URLEndpoint.V4_SUMMONER_BY_ACCOUNT,
+        URLEndpoint.V4_SUMMONER_BY_ID,
+        URLEndpoint.V4_SUMMONER_BY_PUUID,
+        URLEndpoint.V1_TFT_SUMMONER_BY_ACCOUNT,
+        URLEndpoint.V1_TFT_SUMMONER_BY_ID,
+        URLEndpoint.V1_TFT_SUMMONER_BY_PUUID);
+    if (summonerEndpoints.contains(this.dc.getEndpoint()))
+    {
+      returnValue = postProcessSummoner(returnValue);
+    }
+
+    final List<URLEndpoint> apexEndpoints = Arrays.asList(URLEndpoint.V4_LEAGUE_MASTER, URLEndpoint.V4_LEAGUE_GRANDMASTER, URLEndpoint.V4_LEAGUE_CHALLENGER,
+        URLEndpoint.V1_TFT_LEAGUE_MASTER, URLEndpoint.V1_TFT_LEAGUE_GRANDMASTER, URLEndpoint.V1_TFT_LEAGUE_CHALLENGER);
+    if (apexEndpoints.contains(this.dc.getEndpoint()))
+    {
+      returnValue = postProcessApex(returnValue);
+    }
+
+    return returnValue;
+  }
+
+  private String postProcessApex(String returnValue)
+  {
+    JsonObject elem    = (JsonObject) JsonParser.parseString(returnValue);
+    JsonArray  entries = elem.getAsJsonArray("entries");
+    if (entries == null)
+    {
+      entries = new JsonArray();
+    }
+
+    entries.forEach(e -> {
+      JsonObject ob = (JsonObject) e;
+      ob.add("leagueId", elem.get("leagueId"));
+      ob.add("queueType", elem.get("queue"));
+      ob.add("tier", elem.get("tier"));
+    });
+
+    return Utils.getGson().toJson(elem);
+  }
+
+  private String postProcessDDragonMany(String returnValue)
+  {
+    JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
+    JsonObject parent = elem.getAsJsonObject("data");
+    for (String key : new HashSet<>(parent.keySet()))
+    {
+      JsonObject child = parent.getAsJsonObject(key);
+      String     id    = child.get("key").getAsString();
+      child.addProperty("key", key);
+      child.addProperty("id", id);
+      parent.add(id, child);
+      parent.remove(key);
+    }
+
+    return Utils.getGson().toJson(elem);
+  }
+
+  private String postProcessDDragonAddId(String returnValue)
+  {
+    JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
+    JsonObject parent = elem.getAsJsonObject("data");
+    for (String key : new HashSet<>(parent.keySet()))
+    {
+      JsonObject child = parent.getAsJsonObject(key);
+      try 
+      {
+        int keyAsInt = Integer.parseInt(key);
+        child.addProperty("id", keyAsInt);
+
+      }   catch(NumberFormatException e) 
+      {
+        parent.remove(key);
+        logger.warn("Item/Rune received without a valid Id ({}), item removed from the list", key);
+      }
+    }
+
+    return Utils.getGson().toJson(elem);
+  }
+
+  private String postProcessPerkPath(String returnValue)
+  {
+    JsonObject elem     = (JsonObject) JsonParser.parseString(returnValue);
+    String     pathName = elem.get("name").getAsString();
+    String     pathId   = elem.get("id").getAsString();
+
+    JsonArray slots = elem.getAsJsonArray("slots");
+    for (JsonElement slot : slots)
+    {
+      JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
+      for (JsonElement rune : runes)
+      {
+        JsonObject obj = (JsonObject) rune;
+        obj.addProperty("runePathName", pathName);
+        obj.addProperty("runePathId", pathId);
+      }
+    }
+
+    return Utils.getGson().toJson(elem);
+  }
+
+  private String postProcessPerkPaths(String returnValue)
+  {
+    JsonArray element = (JsonArray) JsonParser.parseString(returnValue);
+
+    for (JsonElement elem : element)
+    {
+      String pathName = elem.getAsJsonObject().get("name").getAsString();
+      String pathId   = elem.getAsJsonObject().get("id").getAsString();
+
+      JsonArray slots = elem.getAsJsonObject().getAsJsonArray("slots");
+      for (JsonElement slot : slots)
+      {
+        JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
+        for (JsonElement rune : runes)
+        {
+          JsonObject obj = (JsonObject) rune;
+          obj.addProperty("runePathName", pathName);
+          obj.addProperty("runePathId", pathId);
+        }
+      }
+    }
+
+    return Utils.getGson().toJson(element);
+  }
+
+  private String postProcessSummoner(String returnValue)
+  {
+    JsonObject element = (JsonObject) JsonParser.parseString(returnValue);
+    element.addProperty("platform", this.dc.getPlatform().toString());
+    return Utils.getGson().toJson(element);
+  }
+
+  private Object sleepAndRetry(int[] retrys, int errorCode)
+  {
+    try
+    {
+      int  attempts           = (retrys != null && retrys.length == 1) ? ++retrys[0] : 1;
+      long nextSleepDuration  = attempts * 500L;
+      long totalSleepDuration = 0;
+      for (int i = 1; i < attempts; i++)
+      {
+        totalSleepDuration += i * 500L;
+      }
+
+
+      String message = "";
+      if (errorCode == 429)
+      {
+        message = "Ratelimit reached too many times, waiting " + nextSleepDuration / 1000 + " seconds then retrying";
+      } else
+      {
+        message = "Server error (" + errorCode + ") , waiting " + nextSleepDuration / 1000 + " seconds then retrying";
+      }
+
+      logger.info(message);
+
+      if (totalSleepDuration > this.dc.getMaxSleep())
+      {
+        throw new APINoValidResponseException(String.format("API did not return a valid response in time. Total sleep time is over the max sleep value %s > %s...\n" +
+            "Try setting `DataCall.setDefaultMaxSleep(long)` to a larger number (default is 10000)",
+            (nextSleepDuration + totalSleepDuration), this.dc.getMaxSleep()));
+      }
+
+      Thread.sleep(nextSleepDuration);
+      return this.build(attempts);
+    } catch (InterruptedException e)
+    {
+      throw new APINoValidResponseException("Something interupted the API timeout;" + e.getMessage());
+    }
+  }
+
+  public static final ReentrantLock lock = new ReentrantLock();
+
+  private void applyLimit(Enum platform, Enum endpoint)
+  {
+    lock.lock();
+    try
+    {
+      Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
+
+      if (child.get(endpoint) == null)
+      {
+        loadLimiterFromCache(platform, endpoint, child);
+      }
+    } finally
+    {
+      lock.unlock();
+    }
+
+    RateLimiter limitr = DataCall.getLimiter().getOrDefault(platform, new HashMap<>()).get(endpoint);
+
+    if (limitr != null)
+    {
+      limitr.acquire();
+      storeLimiter(platform, endpoint);
+    }
+  }
+
+  private void storeLimiter(Enum platform, Enum endpoint)
+  {
+    RateLimiter limiter  = DataCall.getLimiter().get(platform).get(endpoint);
+    String      baseKey  = platform.toString() + "/" + endpoint.toString();
+    String      limitKey = "limits/" + baseKey;
+    String      firstKey = "first/" + baseKey;
+    String      callKey  = "call/" + baseKey;
+
+    DataCall.getRatelimiterCache().put(firstKey, Utils.getGson().toJson(limiter.getFirstCallInTime()));
+    DataCall.getRatelimiterCache().put(callKey, Utils.getGson().toJson(limiter.getCallCountInTime()));
+  }
+
+  private void loadLimiterFromCache(Enum platform, Enum endpoint, Map<Enum, RateLimiter> child)
+  {
+    String baseKey  = platform.toString() + "/" + endpoint.toString();
+    String limitKey = "limits/" + baseKey;
+    String firstKey = "first/" + baseKey;
+    String callKey  = "call/" + baseKey;
+
+    String lastLimit = DataCall.getRatelimiterCache().get(limitKey, null);
+    String lastFirst = DataCall.getRatelimiterCache().get(firstKey, null);
+    String lastKey   = DataCall.getRatelimiterCache().get(callKey, null);
+
+    if (lastLimit == null)
+    {
+      logger.debug("No instance of an old ratelimiter found");
+      return;
+    } else
+    {
+      logger.debug("Loading old ratelimiter data");
+    }
+
+    try
+    {
+      List<RateLimit>            knownLimits = Utils.getGson().fromJson(lastLimit, new TypeToken<List<RateLimit>>() {}.getType());
+      Map<RateLimit, AtomicLong> knownTime   = Utils.getGson().fromJson(lastFirst, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
+      Map<RateLimit, AtomicLong> knownCount  = Utils.getGson().fromJson(lastKey, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
+
+
+      RateLimiter newerLimit = new BurstRateLimiter(knownLimits);
+      newerLimit.setCallCountInTime(knownCount);
+      newerLimit.setFirstCallInTime(knownTime);
+
+      logger.debug("Loaded ratelimit for {}", endpoint);
+
+      child.put(endpoint, newerLimit);
+      DataCall.getLimiter().put(platform, child);
+    } catch (JsonSyntaxException s)
+    {
+      try
+      {
+        logger.debug("Old ratelimiter was of incompatible type, re-creating");
+        DataCall.getRatelimiterCache().clear();
+        DataCall.getRatelimiterCache().sync();
+      } catch (BackingStoreException e)
+      {
+        e.printStackTrace();
+      }
+    }
+  }
+
+
+  /**
+   * Opens a connection to the URL, then reads the data into a Response.
+   *
+   * @param url the URL to call
+   * @return a DataCallResponse with the data from the call
+   * @throws APINoValidResponseException if the datacall failed in any fashion
+   */
+  private DataCallResponse getResponse(final String url)
+  {
+    final StringBuilder data = new StringBuilder();
+    try
+    {
+      final HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
+
+      con.setUseCaches(false);
+      con.setDefaultUseCaches(false);
+      con.setRequestProperty("User-Agent", "R4J");
+      con.setRequestProperty("Accept-Charset", "ISO-8859-1,utf-8");
+      con.setRequestProperty("Accept-Language", "en-US");
+      con.setRequestProperty("Cache-Control", "no-store,max-age=0,no-cache");
+      con.setRequestProperty("Expires", "0");
+      con.setRequestProperty("Pragma", "no-cache");
+      con.setRequestProperty("Connection", "keep-alive");
+      con.setRequestProperty("Content-Type", "application/json");
+      con.setConnectTimeout(this.dc.getConnectTimeout());
+      con.setReadTimeout(this.dc.getReadTimeout());
+      this.dc.getUrlHeaders().forEach(con::setRequestProperty);
+
+      if (requestMethod.equalsIgnoreCase("PATCH"))
+      {
+        con.setRequestProperty("X-HTTP-Method-Override", "PATCH");
+        con.setRequestMethod("POST");
+      } else
+      {
+        con.setRequestMethod(requestMethod);
+      }
+
+      StringBuilder sb = new StringBuilder();
+      con.getRequestProperties().forEach((key, value) -> sb.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
+
+      String printMe = new StringBuilder("\n")
+          .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Url", url)).append("\n")
+          .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Method", con.getRequestMethod())).append("\n")
+          .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "POST data", this.postData)).append("\n")
+          .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Headers", "")).append("\n")
+          .append(sb).toString();
+
+      //logger.debug(printMe);
+
+
+      if (null != this.postData && !this.postData.isEmpty())
+      {
+        con.setDoOutput(true);
+        final DataOutputStream writer = new DataOutputStream(con.getOutputStream());
+        writer.writeBytes(this.postData);
+        writer.flush();
+        writer.close();
+      }
+
+      con.connect();
+
+      StringBuilder sb2 = new StringBuilder("\n");
+      con.getHeaderFields().forEach((key, value) -> sb2.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
+
+      String printMe2 = new StringBuilder("\n").append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Response Headers", ""))
+          .append(sb2)
+          .toString();
+      //logger.debug(printMe2);
+
+
+      String appA    = con.getHeaderField("X-App-Rate-Limit");
+      String appB    = con.getHeaderField("X-App-Rate-Limit-Count");
+      String methodA = con.getHeaderField("X-Method-Rate-Limit");
+      String methodB = con.getHeaderField("X-Method-Rate-Limit-Count");
+
+      if (appA == null)
+      {
+        logger.debug("Header 'X-App-Rate-Limit' missing from call: {} ", getURL());
+      } else
+      {
+        lock.lock();
+        createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
+        saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
+        lock.unlock();
+      }
+
+      if (methodA == null)
+      {
+        logger.debug("Header 'X-Method-Rate-Limit' missing from call: {}", getURL());
+      } else
+      {
+        lock.lock();
+        createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
+        saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
+        lock.unlock();
+      }
+
+      String deprecationHeader = con.getHeaderField("X-Riot-Deprecated");
+      if (deprecationHeader != null)
+      {
+        LocalDateTime timeout = LocalDateTime.ofEpochSecond(Long.parseLong(deprecationHeader) / 1000, 0, ZoneOffset.ofHours(-7));
+        logger.info("You are using a deprecated method, this method will stop working at: {}", timeout);
+      }
+
+      if (con.getResponseCode() == 429)
+      {
+        final RateLimitType limitType = RateLimitType.getBestMatch(con.getHeaderField("X-Rate-Limit-Type"));
+
+        StringBuilder valueList = new StringBuilder();
+        DataCall.getLimiter().get(dc.getPlatform()).forEach((key, value) -> {
+          valueList.append(key);
+          valueList.append("=");
+          valueList.append(value.getCallCountInTime());
+          valueList.append("\n");
+        });
+
+        String reasonString = String.format("%s%n%s", limitType.getReason(), valueList.toString().trim());
+        String reason       = String.format("%s%n", reasonString);
+
+        if (limitType == RateLimitType.LIMIT_METHOD)
+        {
+          RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getEndpoint());
+          limter.updateSleep(con.getHeaderField("Retry-After"));
+        }
+
+        if (limitType == RateLimitType.LIMIT_USER)
+        {
+
+          RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getPlatform());
+          limter.updateSleep(con.getHeaderField("Retry-After"));
+        }
+
+        return new DataCallResponse(con.getResponseCode(), reason);
+      }
+
+      if (con.getResponseCode() == 204)
+      {
+        return new DataCallResponse(con.getResponseCode(), "");
+      }
+
+      InputStream stream = (con.getResponseCode() <= 399) ? con.getInputStream() : con.getErrorStream();
+
+      if (stream == null)
+      {
+        return new DataCallResponse(con.getResponseCode(), "Unable to read stream!");
+      }
+
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)))
+      {
+        br.lines().forEach(data::append);
+      }
+
+      con.disconnect();
+
+      return new DataCallResponse(con.getResponseCode(), data.toString());
+    } catch (final IOException e)
+    {
+      throw new APIResponseException(APIHTTPErrorReason.ERROR_599, APIHTTPErrorReason.ERROR_599.getReason());
+    }
+  }
+
+  private void createRatelimiterIfMissing(String methodA, Enum platform, Enum endpoint)
+  {
+    Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
+
+    RateLimiter oldLimit   = child.get(endpoint);
+    RateLimiter newerLimit = createLimiter(methodA);
+
+    if (!newerLimit.equals(oldLimit))
+    {
+      newerLimit.mergeFrom(oldLimit);
+      child.put(endpoint, newerLimit);
+
+      logger.debug("Updating Ratelimit For {}", endpoint);
+      logger.debug(newerLimit.getLimits().toString());
+    }
+
+    DataCall.getLimiter().put(platform, child);
+  }
+
+  private void saveHeaderRateLimit(String limitCount, Enum platform, Enum endpoint)
+  {
+    Map<Enum, Map<Integer, Integer>> parent = DataCall.getCallData().getOrDefault(platform, new HashMap<>());
+    Map<Integer, Integer>            child  = parent.getOrDefault(endpoint, new HashMap<>());
+
+    child.putAll(parseLimitFromHeader(limitCount));
+    parent.put(endpoint, child);
+    DataCall.getCallData().put(platform, parent);
+
+    updateRatelimiter(platform, endpoint);
+    storeLimiter(platform, endpoint);
+  }
+
+  private Map<Integer, Integer> parseLimitFromHeader(String headerValue)
+  {
+    final String[]        limits  = headerValue.split(",");
+    Map<Integer, Integer> timeout = new HashMap<>();
+    for (final String limitPair : limits)
+    {
+      final String[] limit = limitPair.split(":");
+      // tentative fix: when we receive a limit, a given number of calls could have been made since we work in async. We add this to the limit
+      final Integer  call  = Integer.parseInt(limit[0] + NUMBER_OF_CALLS_ALLOWED_IN_ASYNC);
+      final Integer  time  = Integer.parseInt(limit[1]);
+      timeout.put(time, call);
+    }
+
+    return timeout;
+  }
+
+  public RateLimiter createLimiter(String limitCount)
+  {
+    Map<Integer, Integer> timeout = parseLimitFromHeader(limitCount);
+
+    List<RateLimit> limits = new ArrayList<>();
+    for (Entry<Integer, Integer> entry : timeout.entrySet())
+    {
+      limits.add(new RateLimit(entry.getValue(), entry.getKey(), TimeUnit.SECONDS));
+    }
+
+    return new BurstRateLimiter(limits);
+  }
+
+  /**
+   * Generates the URL to use for the call.
+   *
+   * @return the URL to use for the call.
+   */
+  private String getURL()
+  {
+    String[] url = {dc.getProxy()};
+    if (dc.getEndpoint() != null)
+    {
+      url[0] = url[0].replace(Constants.GAME_PLACEHOLDER, dc.getEndpoint().getGame());
+      url[0] = url[0].replace(Constants.SERVICE_PLACEHOLDER, dc.getEndpoint().getService());
+      url[0] = url[0].replace(Constants.VERSION_PLACEHOLDER, dc.getEndpoint().getVersion());
+      url[0] = url[0].replace(Constants.RESOURCE_PLACEHOLDER, dc.getEndpoint().getResource());
+    }
+    if (dc.getPlatform() != null)
+    {
+      url[0] = url[0].replace(Constants.PLATFORM_PLACEHOLDER, dc.getPlatform().toString().toLowerCase());
+      url[0] = url[0].replace(Constants.REGION_PLACEHOLDER, ((RealmSpesificEnum) dc.getPlatform()).getRealmValue());
+    }
+    dc.getUrlParams().forEach((k, v) -> url[0] = url[0].replace(k, v));
+
+    boolean first = true;
+    for (Entry<String, String> pair : dc.getUrlData().entrySet())
+    {
+      char token = first ? '?' : '&';
+
+      if (first)
+      {
+        first = !first;
+      }
+
+      url[0] = url[0] + token + pair.getKey() + '=' + pair.getValue();
+    }
+
+    return url[0];
+  }
+
+
+  /**
+   * Sets the endpoint to make the call to
+   *
+   * @param endpoint the endpoint to make the call to
+   * @return this
+   */
+  public DataCallBuilder withEndpoint(final URLEndpoint endpoint)
+  {
+    this.dc.setEndpoint(endpoint);
+    return this;
+  }
+
+  /**
+   * enables ratelimiters for this call
+   *
+   * @param flag enabled or disabled
+   * @return this
+   */
+  public DataCallBuilder withLimiters(final boolean flag)
+  {
+    this.dc.setUseLimiters(flag);
+    return this;
+  }
+
+  /**
+   * Sets the headers to use with the call
+   *
+   * @param key   the header key
+   * @param value the header value
+   * @return this
+   */
+  public DataCallBuilder withHeader(final String key, final String value)
+  {
+    this.dc.getUrlHeaders().merge(key, value, MERGE);
+    return this;
+  }
+
+  /**
+   * Sets the data to send with the request if its a POST call
+   *
+   * @param data the data to send
+   * @return this
+   */
+  public DataCallBuilder withPostData(final String data)
+  {
+    this.postData = data;
+    return this;
+  }
+
+
+  /**
+   * The request-method on the call (usually GET or POST)
+   *
+   * @param method the request method
+   * @return this
+   */
+  public DataCallBuilder withRequestMethod(final String method)
+  {
+    this.requestMethod = method;
+    return this;
+  }
+
+  /**
+   * Set the platform to make this call to. (ie. EUW1)
+   *
+   * @param server the server to make the call to
+   * @return this
+   */
+  public DataCallBuilder withPlatform(final Enum server)
+  {
+    this.dc.setPlatform(server);
+    return this;
+  }
+
+  /**
+   * Replaces placeholders in the URL (ie. {region})
+   *
+   * @param key   The key to replace (ie. {region})
+   * @param value The data to replace it with (ie. EUW)
+   * @return this
+   */
+  public DataCallBuilder withURLDataAsSet(final String key, final String value)
+  {
+    this.dc.getUrlData().merge(key, (this.dc.getUrlData().get(key) != null) ? ("&" + key + "=" + value) : value, MERGE_AS_SET);
+    return this;
+  }
+
+
+  /**
+   * Adds parameters to the url (ie. ?api_key)
+   *
+   * @param key   the parameter to add (ie. api_key)
+   * @param value the value to add after the parameter (ie. 6fa459ea-ee8a-3ca4-894e-db77e160355e)
+   * @return this
+   */
+  public DataCallBuilder withQueryParameter(final String key, final String value)
+  {
+    this.dc.getUrlData().merge(key, value, MERGE);
+    return this;
+  }
+
+  /**
+   * Replaces placeholders in the URL (ie. {region})
+   *
+   * @param key   The key to replace (ie. {region})
+   * @param value The data to replace it with (ie. EUW)
+   * @return this
+   */
+  public DataCallBuilder withURLParameter(final String key, final String value)
+  {
+    this.dc.getUrlParams().merge(key, value, MERGE);
+    return this;
+  }
+
+  public DataCallBuilder withProxy(String proxy)
+  {
+    this.dc.setProxy(proxy);
+    return this;
+  }
 }

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -586,7 +586,7 @@ public class DataCallBuilder
 				try {
 					getLock(dc.getPlatform()).lock();
 					createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
-					saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
+					//saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
 				}finally {
 					getLock(dc.getPlatform()).unlock();
 				}
@@ -600,7 +600,7 @@ public class DataCallBuilder
 				try {
 					getLock(dc.getPlatform()).lock();
 					createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
-					saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
+					//saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
 				} finally {
 					getLock(dc.getPlatform()).unlock();
 				}

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -702,8 +702,7 @@ public class DataCallBuilder
     for (final String limitPair : limits)
     {
       final String[] limit = limitPair.split(":");
-      // tentative fix: when we receive a limit, a given number of calls could have been made since we work in async. We add this to the limit
-      final Integer  call  = Integer.parseInt(limit[0] + NUMBER_OF_CALLS_ALLOWED_IN_ASYNC);
+      final Integer  call  = Integer.parseInt(limit[0]);
       final Integer  time  = Integer.parseInt(limit[1]);
       timeout.put(time, call);
     }

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -18,6 +18,7 @@ import java.security.cert.X509Certificate;
 import java.time.*;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
@@ -27,844 +28,855 @@ import java.util.prefs.BackingStoreException;
 @SuppressWarnings("rawtypes")
 public class DataCallBuilder
 {
-    private static final Logger logger = LoggerFactory.getLogger(DataCallBuilder.class);
-    
-    private final DataCall dc = new DataCall();
-    
-    private static final BiFunction<String, String, String> MERGE        = (o, n) -> o + "," + n;
-    private static final BiFunction<String, String, String> MERGE_AS_SET = (o, n) -> o + n;
-    
-    private String requestMethod = "GET";
-    private String postData      = "";
-    
-    private static final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager()
-    {
-        public java.security.cert.X509Certificate[] getAcceptedIssuers()
-        {
-            return null;
-        }
-        
-        public void checkClientTrusted(X509Certificate[] certs, String authType)
-        {
-        }
-        
-        public void checkServerTrusted(X509Certificate[] certs, String authType)
-        {
-        }
-    }
-    };
-    
-    // Create all-trusting host name verifier
-    private static final HostnameVerifier allHostsValid = (hostname, session) -> true;
-    
-    static
-    {
-        try
-        {
-            // Install the all-trusting trust manager
-            SSLContext sc = SSLContext.getInstance("SSL");
-            sc.init(null, trustAllCerts, new java.security.SecureRandom());
-            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-        } catch (KeyManagementException | NoSuchAlgorithmException e)
-        {
-            e.printStackTrace();
-        }
-    }
-    
-    
-    private static void updateRatelimiter(Enum server, Enum endpoint)
-    {
-        RateLimiter limiter = DataCall.getLimiter().get(server).get(endpoint);
-        limiter.updatePermitsTakenPerX(DataCall.getCallData().get(server).get(endpoint));
-    }
-    
-    private static final Map<URLEndpoint, AtomicLong> requestCount = new HashMap<>();
-    
-    /**
-     * Puts together all the data, and then returns an object representing the JSON from the call
-     *
-     * @param retrys the amount of retries already done (should not be passed in!)
-     * @return an object generated from the requested JSON
-     */
-    public Object build(int... retrys)
-    {
-        final String url = this.getURL();
-        logger.info("Trying url: {}", url);
-        
-        if (this.dc.useRatelimiter())
-        {
-            if (DataCall.getCredentials() == null)
-            {
-                throw new APIUnsupportedActionException("No API Creds set!");
-            }
-            
-            dc.getUrlHeaders().putIfAbsent("X-Riot-Token", DataCall.getCredentials().getLoLAPIKey());
-            
-            // app limit
-            applyLimit(this.dc.getPlatform(), this.dc.getPlatform());
-            // method limit
-            applyLimit(this.dc.getPlatform(), this.dc.getEndpoint());
-        }
-        
-        
-        final DataCallResponse response = this.getResponse(url);
-        logger.debug(response.toString());
-        
-        switch (response.getResponseCode())
-        {
-            case 200:
-            case 201:
-            case 204:
-            {
-                String returnValue = response.getResponseData();
-                
-                if (this.dc.shouldReturnRawResponse())
-                {
-                    return returnValue;
-                }
-                
-                if (this.dc.getEndpoint() != null)
-                {
-                    final Class<?> returnType = this.dc.getEndpoint().getType();
-                    returnValue = postProcess(returnValue);
-                    
-                    return Utils.getGson().fromJson(returnValue, returnType);
-                } else
-                {
-                    return returnValue;
-                }
-            }
-            
-            case 400:
-            {
-                String reasonText = "Your api request is malformed!\n";
-                reasonText += url + "\n";
-                throw new APIResponseException(APIHTTPErrorReason.ERROR_400, reasonText + response.getResponseData());
-            }
-            
-            case 401:
-            {
-                
-                String reasonText = "The API denied your request!\n";
-                reasonText += "Your API key was not present in the request\n";
-                reasonText += "Make sure you have setup your APICredentials before doing a API call!\n";
-                throw new APIResponseException(APIHTTPErrorReason.ERROR_401, reasonText + response.getResponseData());
-            }
-            
-            case 403:
-            {
-                
-                String reasonText = "The API denied your request!\n";
-                reasonText += "Possible reasons:\n";
-                reasonText += " - Your API key is invalid\n";
-                reasonText += " - You just regenerated the key; wait a few seconds, then try again\n";
-                reasonText += " - You are trying to call a endpoint you dont have access to\n";
-                throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
-            }
-            
-            case 404:
-            {
-                return new Pair<>(response.getResponseCode(), response.getResponseData());
-            }
-            
-            case 405:
-            {
-                String reasonText = "The API was unable to handle your request due to the wrong HTTP method being used.\n";
-                throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
-            }
-            case 429:
-                if (response.getResponseData().startsWith(RateLimitType.LIMIT_UNDERLYING.getReason()) || response.getResponseData().startsWith(RateLimitType.LIMIT_SERVICE.getReason()))
-                {
-                    return sleepAndRetry(retrys, response.getResponseCode());
-                } else
-                {
-                    String error = response.getResponseData() + "429 ratelimit hit! " +
-                                   "Please do not restart your application to refresh the timer! " +
-                                   "This isn't supposed to happen unless you restarted your app before the last limit was hit!";
-                    
-                    logger.error(error);
-                    
-                }
-                
-                return this.build();
-            
-            case 500:
-            case 502:
-            case 503:
-            case 504:
-            {
-                return sleepAndRetry(retrys, response.getResponseCode());
-            }
-            
-            case 599:
-            {
-                throw new APIResponseException(APIHTTPErrorReason.ERROR_599, response.getResponseData());
-            }
-            
-            default:
-            {
-                break;
-            }
-        }
-        
-        System.err.println("UNHANDLED RESPONSE CODE!!!");
-        System.err.println("Response Code:" + response.getResponseCode());
-        System.err.println("Response Data:" + response.getResponseData());
-        throw new APINoValidResponseException(response.getResponseData());
-    }
-    
-    private String postProcess(String returnValue)
-    {
-        final List<URLEndpoint> ddragon = Arrays.asList(URLEndpoint.DDRAGON_CHAMPION_MANY, URLEndpoint.DDRAGON_SUMMONER_SPELLS);
-        if (ddragon.contains(this.dc.getEndpoint()))
-        {
-            returnValue = postProcessDDragonMany(returnValue);
-        }
-        
-        if (this.dc.getEndpoint() == URLEndpoint.DDRAGON_ITEMS || this.dc.getEndpoint() == URLEndpoint.DDRAGON_RUNES)
-        {
-            returnValue = postProcessDDragonAddId(returnValue);
-        }
-        
-        final List<URLEndpoint> summonerEndpoints = Arrays.asList(
-                URLEndpoint.V4_SUMMONER_BY_ACCOUNT,
-                URLEndpoint.V4_SUMMONER_BY_ID,
-                URLEndpoint.V4_SUMMONER_BY_PUUID,
-                URLEndpoint.V1_TFT_SUMMONER_BY_ACCOUNT,
-                URLEndpoint.V1_TFT_SUMMONER_BY_ID,
-                URLEndpoint.V1_TFT_SUMMONER_BY_PUUID);
-        if (summonerEndpoints.contains(this.dc.getEndpoint()))
-        {
-            returnValue = postProcessSummoner(returnValue);
-        }
-        
-        final List<URLEndpoint> apexEndpoints = Arrays.asList(URLEndpoint.V4_LEAGUE_MASTER, URLEndpoint.V4_LEAGUE_GRANDMASTER, URLEndpoint.V4_LEAGUE_CHALLENGER,
-                                                              URLEndpoint.V1_TFT_LEAGUE_MASTER, URLEndpoint.V1_TFT_LEAGUE_GRANDMASTER, URLEndpoint.V1_TFT_LEAGUE_CHALLENGER);
-        if (apexEndpoints.contains(this.dc.getEndpoint()))
-        {
-            returnValue = postProcessApex(returnValue);
-        }
-        
-        return returnValue;
-    }
-    
-    private String postProcessApex(String returnValue)
-    {
-        JsonObject elem    = (JsonObject) JsonParser.parseString(returnValue);
-        JsonArray  entries = elem.getAsJsonArray("entries");
-        if (entries == null)
-        {
-            entries = new JsonArray();
-        }
-        
-        entries.forEach(e -> {
-            JsonObject ob = (JsonObject) e;
-            ob.add("leagueId", elem.get("leagueId"));
-            ob.add("queueType", elem.get("queue"));
-            ob.add("tier", elem.get("tier"));
-        });
-        
-        return Utils.getGson().toJson(elem);
-    }
-    
-    private String postProcessDDragonMany(String returnValue)
-    {
-        JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
-        JsonObject parent = elem.getAsJsonObject("data");
-        for (String key : new HashSet<>(parent.keySet()))
-        {
-            JsonObject child = parent.getAsJsonObject(key);
-            String     id    = child.get("key").getAsString();
-            child.addProperty("key", key);
-            child.addProperty("id", id);
-            parent.add(id, child);
-            parent.remove(key);
-        }
-        
-        return Utils.getGson().toJson(elem);
-    }
-    
-    private String postProcessDDragonAddId(String returnValue)
-    {
-        JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
-        JsonObject parent = elem.getAsJsonObject("data");
-        for (String key : new HashSet<>(parent.keySet()))
-        {
-            JsonObject child = parent.getAsJsonObject(key);
-            try 
-            {
-                int keyAsInt = Integer.parseInt(key);
-                child.addProperty("id", keyAsInt);
-                
-            }   catch(NumberFormatException e) 
-            {
-                parent.remove(key);
-                logger.warn("Item/Rune received without a valid Id ({}), item removed from the list", key);
-            }
-        }
-        
-        return Utils.getGson().toJson(elem);
-    }
-    
-    private String postProcessPerkPath(String returnValue)
-    {
-        JsonObject elem     = (JsonObject) JsonParser.parseString(returnValue);
-        String     pathName = elem.get("name").getAsString();
-        String     pathId   = elem.get("id").getAsString();
-        
-        JsonArray slots = elem.getAsJsonArray("slots");
-        for (JsonElement slot : slots)
-        {
-            JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
-            for (JsonElement rune : runes)
-            {
-                JsonObject obj = (JsonObject) rune;
-                obj.addProperty("runePathName", pathName);
-                obj.addProperty("runePathId", pathId);
-            }
-        }
-        
-        return Utils.getGson().toJson(elem);
-    }
-    
-    private String postProcessPerkPaths(String returnValue)
-    {
-        JsonArray element = (JsonArray) JsonParser.parseString(returnValue);
-        
-        for (JsonElement elem : element)
-        {
-            String pathName = elem.getAsJsonObject().get("name").getAsString();
-            String pathId   = elem.getAsJsonObject().get("id").getAsString();
-            
-            JsonArray slots = elem.getAsJsonObject().getAsJsonArray("slots");
-            for (JsonElement slot : slots)
-            {
-                JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
-                for (JsonElement rune : runes)
-                {
-                    JsonObject obj = (JsonObject) rune;
-                    obj.addProperty("runePathName", pathName);
-                    obj.addProperty("runePathId", pathId);
-                }
-            }
-        }
-        
-        return Utils.getGson().toJson(element);
-    }
-    
-    private String postProcessSummoner(String returnValue)
-    {
-        JsonObject element = (JsonObject) JsonParser.parseString(returnValue);
-        element.addProperty("platform", this.dc.getPlatform().toString());
-        return Utils.getGson().toJson(element);
-    }
-    
-    private Object sleepAndRetry(int[] retrys, int errorCode)
-    {
-        try
-        {
-            int  attempts           = (retrys != null && retrys.length == 1) ? ++retrys[0] : 1;
-            long nextSleepDuration  = attempts * 500L;
-            long totalSleepDuration = 0;
-            for (int i = 1; i < attempts; i++)
-            {
-                totalSleepDuration += i * 500L;
-            }
-            
-            
-            String message = "";
-            if (errorCode == 429)
-            {
-                message = "Ratelimit reached too many times, waiting " + nextSleepDuration / 1000 + " seconds then retrying";
-            } else
-            {
-                message = "Server error (" + errorCode + ") , waiting " + nextSleepDuration / 1000 + " seconds then retrying";
-            }
-            
-            logger.info(message);
-            
-            if (totalSleepDuration > this.dc.getMaxSleep())
-            {
-                throw new APINoValidResponseException(String.format("API did not return a valid response in time. Total sleep time is over the max sleep value %s > %s...\n" +
-                                                                    "Try setting `DataCall.setDefaultMaxSleep(long)` to a larger number (default is 10000)",
-                                                                    (nextSleepDuration + totalSleepDuration), this.dc.getMaxSleep()));
-            }
-            
-            Thread.sleep(nextSleepDuration);
-            return this.build(attempts);
-        } catch (InterruptedException e)
-        {
-            throw new APINoValidResponseException("Something interupted the API timeout;" + e.getMessage());
-        }
-    }
-    
-    public static final ReentrantLock lock = new ReentrantLock();
-    
-    private void applyLimit(Enum platform, Enum endpoint)
-    {
-        lock.lock();
-        try
-        {
-            Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
-            
-            if (child.get(endpoint) == null)
-            {
-                loadLimiterFromCache(platform, endpoint, child);
-            }
-        } finally
-        {
-            lock.unlock();
-        }
-        
-        RateLimiter limitr = DataCall.getLimiter().getOrDefault(platform, new HashMap<>()).get(endpoint);
-        
-        if (limitr != null)
-        {
-            limitr.acquire();
-            storeLimiter(platform, endpoint);
-        }
-    }
-    
-    private void storeLimiter(Enum platform, Enum endpoint)
-    {
-        RateLimiter limiter  = DataCall.getLimiter().get(platform).get(endpoint);
-        String      baseKey  = platform.toString() + "/" + endpoint.toString();
-        String      limitKey = "limits/" + baseKey;
-        String      firstKey = "first/" + baseKey;
-        String      callKey  = "call/" + baseKey;
-        
-        DataCall.getRatelimiterCache().put(firstKey, Utils.getGson().toJson(limiter.getFirstCallInTime()));
-        DataCall.getRatelimiterCache().put(callKey, Utils.getGson().toJson(limiter.getCallCountInTime()));
-    }
-    
-    private void loadLimiterFromCache(Enum platform, Enum endpoint, Map<Enum, RateLimiter> child)
-    {
-        String baseKey  = platform.toString() + "/" + endpoint.toString();
-        String limitKey = "limits/" + baseKey;
-        String firstKey = "first/" + baseKey;
-        String callKey  = "call/" + baseKey;
-        
-        String lastLimit = DataCall.getRatelimiterCache().get(limitKey, null);
-        String lastFirst = DataCall.getRatelimiterCache().get(firstKey, null);
-        String lastKey   = DataCall.getRatelimiterCache().get(callKey, null);
-        
-        if (lastLimit == null)
-        {
-            logger.debug("No instance of an old ratelimiter found");
-            return;
-        } else
-        {
-            logger.debug("Loading old ratelimiter data");
-        }
-        
-        try
-        {
-            List<RateLimit>            knownLimits = Utils.getGson().fromJson(lastLimit, new TypeToken<List<RateLimit>>() {}.getType());
-            Map<RateLimit, AtomicLong> knownTime   = Utils.getGson().fromJson(lastFirst, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
-            Map<RateLimit, AtomicLong> knownCount  = Utils.getGson().fromJson(lastKey, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
-            
-            
-            RateLimiter newerLimit = new BurstRateLimiter(knownLimits);
-            newerLimit.setCallCountInTime(knownCount);
-            newerLimit.setFirstCallInTime(knownTime);
-            
-            logger.debug("Loaded ratelimit for {}", endpoint);
-            
-            child.put(endpoint, newerLimit);
-            DataCall.getLimiter().put(platform, child);
-        } catch (JsonSyntaxException s)
-        {
-            try
-            {
-                logger.debug("Old ratelimiter was of incompatible type, re-creating");
-                DataCall.getRatelimiterCache().clear();
-                DataCall.getRatelimiterCache().sync();
-            } catch (BackingStoreException e)
-            {
-                e.printStackTrace();
-            }
-        }
-    }
-    
-    
-    /**
-     * Opens a connection to the URL, then reads the data into a Response.
-     *
-     * @param url the URL to call
-     * @return a DataCallResponse with the data from the call
-     * @throws APINoValidResponseException if the datacall failed in any fashion
-     */
-    private DataCallResponse getResponse(final String url)
-    {
-        final StringBuilder data = new StringBuilder();
-        try
-        {
-            final HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
-            
-            con.setUseCaches(false);
-            con.setDefaultUseCaches(false);
-            con.setRequestProperty("User-Agent", "R4J");
-            con.setRequestProperty("Accept-Charset", "ISO-8859-1,utf-8");
-            con.setRequestProperty("Accept-Language", "en-US");
-            con.setRequestProperty("Cache-Control", "no-store,max-age=0,no-cache");
-            con.setRequestProperty("Expires", "0");
-            con.setRequestProperty("Pragma", "no-cache");
-            con.setRequestProperty("Connection", "keep-alive");
-            con.setRequestProperty("Content-Type", "application/json");
-            con.setConnectTimeout(this.dc.getConnectTimeout());
-            con.setReadTimeout(this.dc.getReadTimeout());
-            this.dc.getUrlHeaders().forEach(con::setRequestProperty);
-            
-            if (requestMethod.equalsIgnoreCase("PATCH"))
-            {
-                con.setRequestProperty("X-HTTP-Method-Override", "PATCH");
-                con.setRequestMethod("POST");
-            } else
-            {
-                con.setRequestMethod(requestMethod);
-            }
-            
-            StringBuilder sb = new StringBuilder();
-            con.getRequestProperties().forEach((key, value) -> sb.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
-            
-            String printMe = new StringBuilder("\n")
-                    .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Url", url)).append("\n")
-                    .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Method", con.getRequestMethod())).append("\n")
-                    .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "POST data", this.postData)).append("\n")
-                    .append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Headers", "")).append("\n")
-                    .append(sb).toString();
-            
-            logger.debug(printMe);
-            
-            
-            if (null != this.postData && !this.postData.isEmpty())
-            {
-                con.setDoOutput(true);
-                final DataOutputStream writer = new DataOutputStream(con.getOutputStream());
-                writer.writeBytes(this.postData);
-                writer.flush();
-                writer.close();
-            }
-            
-            con.connect();
-            
-            StringBuilder sb2 = new StringBuilder("\n");
-            con.getHeaderFields().forEach((key, value) -> sb2.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
-            
-            String printMe2 = new StringBuilder("\n").append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Response Headers", ""))
-                                                     .append(sb2)
-                                                     .toString();
-            logger.debug(printMe2);
-            
-            
-            String appA    = con.getHeaderField("X-App-Rate-Limit");
-            String appB    = con.getHeaderField("X-App-Rate-Limit-Count");
-            String methodA = con.getHeaderField("X-Method-Rate-Limit");
-            String methodB = con.getHeaderField("X-Method-Rate-Limit-Count");
-            
-            if (appA == null)
-            {
-                logger.debug("Header 'X-App-Rate-Limit' missing from call: {} ", getURL());
-            } else
-            {
-                lock.lock();
-                createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
-                saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
-                lock.unlock();
-            }
-            
-            if (methodA == null)
-            {
-                logger.debug("Header 'X-Method-Rate-Limit' missing from call: {}", getURL());
-            } else
-            {
-                lock.lock();
-                createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
-                saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
-                lock.unlock();
-            }
-            
-            String deprecationHeader = con.getHeaderField("X-Riot-Deprecated");
-            if (deprecationHeader != null)
-            {
-                LocalDateTime timeout = LocalDateTime.ofEpochSecond(Long.parseLong(deprecationHeader) / 1000, 0, ZoneOffset.ofHours(-7));
-                logger.info("You are using a deprecated method, this method will stop working at: {}", timeout);
-            }
-            
-            if (con.getResponseCode() == 429)
-            {
-                final RateLimitType limitType = RateLimitType.getBestMatch(con.getHeaderField("X-Rate-Limit-Type"));
-                
-                StringBuilder valueList = new StringBuilder();
-                DataCall.getLimiter().get(dc.getPlatform()).forEach((key, value) -> {
-                    valueList.append(key);
-                    valueList.append("=");
-                    valueList.append(value.getCallCountInTime());
-                    valueList.append("\n");
-                });
-                
-                String reasonString = String.format("%s%n%s", limitType.getReason(), valueList.toString().trim());
-                String reason       = String.format("%s%n", reasonString);
-                
-                if (limitType == RateLimitType.LIMIT_METHOD)
-                {
-                    RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getEndpoint());
-                    limter.updateSleep(con.getHeaderField("Retry-After"));
-                }
-                
-                if (limitType == RateLimitType.LIMIT_USER)
-                {
-                	
-                    RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getPlatform());
-                    limter.updateSleep(con.getHeaderField("Retry-After"));
-                }
-                
-                return new DataCallResponse(con.getResponseCode(), reason);
-            }
-            
-            if (con.getResponseCode() == 204)
-            {
-                return new DataCallResponse(con.getResponseCode(), "");
-            }
-            
-            InputStream stream = (con.getResponseCode() <= 399) ? con.getInputStream() : con.getErrorStream();
-            
-            if (stream == null)
-            {
-                return new DataCallResponse(con.getResponseCode(), "Unable to read stream!");
-            }
-            
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)))
-            {
-                br.lines().forEach(data::append);
-            }
-            
-            con.disconnect();
-            
-            return new DataCallResponse(con.getResponseCode(), data.toString());
-        } catch (final IOException e)
-        {
-            throw new APIResponseException(APIHTTPErrorReason.ERROR_599, APIHTTPErrorReason.ERROR_599.getReason());
-        }
-    }
-    
-    private void createRatelimiterIfMissing(String methodA, Enum platform, Enum endpoint)
-    {
-        Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
-        
-        RateLimiter oldLimit   = child.get(endpoint);
-        RateLimiter newerLimit = createLimiter(methodA);
-        
-        if (!newerLimit.equals(oldLimit))
-        {
-            newerLimit.mergeFrom(oldLimit);
-            child.put(endpoint, newerLimit);
-            
-            logger.debug("Updating Ratelimit For {}", endpoint);
-            logger.debug(newerLimit.getLimits().toString());
-        }
-        
-        DataCall.getLimiter().put(platform, child);
-    }
-    
-    private void saveHeaderRateLimit(String limitCount, Enum platform, Enum endpoint)
-    {
-        Map<Enum, Map<Integer, Integer>> parent = DataCall.getCallData().getOrDefault(platform, new HashMap<>());
-        Map<Integer, Integer>            child  = parent.getOrDefault(endpoint, new HashMap<>());
-        
-        child.putAll(parseLimitFromHeader(limitCount));
-        parent.put(endpoint, child);
-        DataCall.getCallData().put(platform, parent);
-        
-        updateRatelimiter(platform, endpoint);
-        storeLimiter(platform, endpoint);
-    }
-    
-    private Map<Integer, Integer> parseLimitFromHeader(String headerValue)
-    {
-        final String[]        limits  = headerValue.split(",");
-        Map<Integer, Integer> timeout = new HashMap<>();
-        for (final String limitPair : limits)
-        {
-            final String[] limit = limitPair.split(":");
-            final Integer  call  = Integer.parseInt(limit[0]);
-            final Integer  time  = Integer.parseInt(limit[1]);
-            timeout.put(time, call);
-        }
-        
-        return timeout;
-    }
-    
-    public RateLimiter createLimiter(String limitCount)
-    {
-        Map<Integer, Integer> timeout = parseLimitFromHeader(limitCount);
-        
-        List<RateLimit> limits = new ArrayList<>();
-        for (Entry<Integer, Integer> entry : timeout.entrySet())
-        {
-            limits.add(new RateLimit(entry.getValue(), entry.getKey(), TimeUnit.SECONDS));
-        }
-        
-        return new BurstRateLimiter(limits);
-    }
-    
-    
-    /**
-     * Generates the URL to use for the call.
-     *
-     * @return the URL to use for the call.
-     */
-    private String getURL()
-    {
-        String[] url = {dc.getProxy()};
-        if (dc.getEndpoint() != null)
-        {
-            url[0] = url[0].replace(Constants.GAME_PLACEHOLDER, dc.getEndpoint().getGame());
-            url[0] = url[0].replace(Constants.SERVICE_PLACEHOLDER, dc.getEndpoint().getService());
-            url[0] = url[0].replace(Constants.VERSION_PLACEHOLDER, dc.getEndpoint().getVersion());
-            url[0] = url[0].replace(Constants.RESOURCE_PLACEHOLDER, dc.getEndpoint().getResource());
-        }
-        if (dc.getPlatform() != null)
-        {
-            url[0] = url[0].replace(Constants.PLATFORM_PLACEHOLDER, dc.getPlatform().toString().toLowerCase());
-            url[0] = url[0].replace(Constants.REGION_PLACEHOLDER, ((RealmSpesificEnum) dc.getPlatform()).getRealmValue());
-        }
-        dc.getUrlParams().forEach((k, v) -> url[0] = url[0].replace(k, v));
-        
-        boolean first = true;
-        for (Entry<String, String> pair : dc.getUrlData().entrySet())
-        {
-            char token = first ? '?' : '&';
-            
-            if (first)
-            {
-                first = !first;
-            }
-            
-            url[0] = url[0] + token + pair.getKey() + '=' + pair.getValue();
-        }
-        
-        return url[0];
-    }
-    
-    
-    /**
-     * Sets the endpoint to make the call to
-     *
-     * @param endpoint the endpoint to make the call to
-     * @return this
-     */
-    public DataCallBuilder withEndpoint(final URLEndpoint endpoint)
-    {
-        this.dc.setEndpoint(endpoint);
-        return this;
-    }
-    
-    /**
-     * enables ratelimiters for this call
-     *
-     * @param flag enabled or disabled
-     * @return this
-     */
-    public DataCallBuilder withLimiters(final boolean flag)
-    {
-        this.dc.setUseLimiters(flag);
-        return this;
-    }
-    
-    /**
-     * Sets the headers to use with the call
-     *
-     * @param key   the header key
-     * @param value the header value
-     * @return this
-     */
-    public DataCallBuilder withHeader(final String key, final String value)
-    {
-        this.dc.getUrlHeaders().merge(key, value, MERGE);
-        return this;
-    }
-    
-    /**
-     * Sets the data to send with the request if its a POST call
-     *
-     * @param data the data to send
-     * @return this
-     */
-    public DataCallBuilder withPostData(final String data)
-    {
-        this.postData = data;
-        return this;
-    }
-    
-    
-    /**
-     * The request-method on the call (usually GET or POST)
-     *
-     * @param method the request method
-     * @return this
-     */
-    public DataCallBuilder withRequestMethod(final String method)
-    {
-        this.requestMethod = method;
-        return this;
-    }
-    
-    /**
-     * Set the platform to make this call to. (ie. EUW1)
-     *
-     * @param server the server to make the call to
-     * @return this
-     */
-    public DataCallBuilder withPlatform(final Enum server)
-    {
-        this.dc.setPlatform(server);
-        return this;
-    }
-    
-    /**
-     * Replaces placeholders in the URL (ie. {region})
-     *
-     * @param key   The key to replace (ie. {region})
-     * @param value The data to replace it with (ie. EUW)
-     * @return this
-     */
-    public DataCallBuilder withURLDataAsSet(final String key, final String value)
-    {
-        this.dc.getUrlData().merge(key, (this.dc.getUrlData().get(key) != null) ? ("&" + key + "=" + value) : value, MERGE_AS_SET);
-        return this;
-    }
-    
-    
-    /**
-     * Adds parameters to the url (ie. ?api_key)
-     *
-     * @param key   the parameter to add (ie. api_key)
-     * @param value the value to add after the parameter (ie. 6fa459ea-ee8a-3ca4-894e-db77e160355e)
-     * @return this
-     */
-    public DataCallBuilder withQueryParameter(final String key, final String value)
-    {
-        this.dc.getUrlData().merge(key, value, MERGE);
-        return this;
-    }
-    
-    /**
-     * Replaces placeholders in the URL (ie. {region})
-     *
-     * @param key   The key to replace (ie. {region})
-     * @param value The data to replace it with (ie. EUW)
-     * @return this
-     */
-    public DataCallBuilder withURLParameter(final String key, final String value)
-    {
-        this.dc.getUrlParams().merge(key, value, MERGE);
-        return this;
-    }
-    
-    public DataCallBuilder withProxy(String proxy)
-    {
-        this.dc.setProxy(proxy);
-        return this;
-    }
+	private static final int NUMBER_OF_CALLS_ALLOWED_IN_ASYNC = 200;
+
+	private static final Logger logger = LoggerFactory.getLogger(DataCallBuilder.class);
+
+	private final DataCall dc = new DataCall();
+
+	private static final BiFunction<String, String, String> MERGE        = (o, n) -> o + "," + n;
+	private static final BiFunction<String, String, String> MERGE_AS_SET = (o, n) -> o + n;
+
+	private String requestMethod = "GET";
+	private String postData      = "";
+
+	private Semaphore semaphore = new Semaphore(NUMBER_OF_CALLS_ALLOWED_IN_ASYNC, true);
+
+	private static final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager()
+	{
+		public java.security.cert.X509Certificate[] getAcceptedIssuers()
+		{
+			return null;
+		}
+
+		public void checkClientTrusted(X509Certificate[] certs, String authType)
+		{
+		}
+
+		public void checkServerTrusted(X509Certificate[] certs, String authType)
+		{
+		}
+	}
+	};
+
+	// Create all-trusting host name verifier
+	private static final HostnameVerifier allHostsValid = (hostname, session) -> true;
+
+	static
+	{
+		try
+		{
+			// Install the all-trusting trust manager
+			SSLContext sc = SSLContext.getInstance("SSL");
+			sc.init(null, trustAllCerts, new java.security.SecureRandom());
+			HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+		} catch (KeyManagementException | NoSuchAlgorithmException e)
+		{
+			e.printStackTrace();
+		}
+	}
+
+
+	private static void updateRatelimiter(Enum server, Enum endpoint)
+	{
+		RateLimiter limiter = DataCall.getLimiter().get(server).get(endpoint);
+		limiter.updatePermitsTakenPerX(DataCall.getCallData().get(server).get(endpoint));
+	}
+
+	private static final Map<URLEndpoint, AtomicLong> requestCount = new HashMap<>();
+
+	/**
+	 * Puts together all the data, and then returns an object representing the JSON from the call
+	 *
+	 * @param retrys the amount of retries already done (should not be passed in!)
+	 * @return an object generated from the requested JSON
+	 */
+	public Object build(int... retrys)
+	{
+		final String url = this.getURL();
+
+		try {
+			semaphore.acquire();
+			if (this.dc.useRatelimiter())
+			{
+				if (DataCall.getCredentials() == null)
+				{
+					throw new APIUnsupportedActionException("No API Creds set!");
+				}
+
+				dc.getUrlHeaders().putIfAbsent("X-Riot-Token", DataCall.getCredentials().getLoLAPIKey());
+
+				// app limit
+				applyLimit(this.dc.getPlatform(), this.dc.getPlatform());
+				// method limit
+				applyLimit(this.dc.getPlatform(), this.dc.getEndpoint());
+			}
+		} catch (InterruptedException e) {
+			logger.error("Semaphore was interrupted while trying to acquire a permit for the API call: {}", url, e);
+			Thread.currentThread().interrupt();
+		}finally {
+			semaphore.release();
+		}
+
+		logger.info("Trying url: {}", url);
+
+		final DataCallResponse response = this.getResponse(url);
+		//logger.debug(response.toString());
+
+		switch (response.getResponseCode())
+		{
+		case 200:
+		case 201:
+		case 204:
+		{
+			String returnValue = response.getResponseData();
+
+			if (this.dc.shouldReturnRawResponse())
+			{
+				return returnValue;
+			}
+
+			if (this.dc.getEndpoint() != null)
+			{
+				final Class<?> returnType = this.dc.getEndpoint().getType();
+				returnValue = postProcess(returnValue);
+
+				return Utils.getGson().fromJson(returnValue, returnType);
+			} else
+			{
+				return returnValue;
+			}
+		}
+
+		case 400:
+		{
+			String reasonText = "Your api request is malformed!\n";
+			reasonText += url + "\n";
+			throw new APIResponseException(APIHTTPErrorReason.ERROR_400, reasonText + response.getResponseData());
+		}
+
+		case 401:
+		{
+
+			String reasonText = "The API denied your request!\n";
+			reasonText += "Your API key was not present in the request\n";
+			reasonText += "Make sure you have setup your APICredentials before doing a API call!\n";
+			throw new APIResponseException(APIHTTPErrorReason.ERROR_401, reasonText + response.getResponseData());
+		}
+
+		case 403:
+		{
+
+			String reasonText = "The API denied your request!\n";
+			reasonText += "Possible reasons:\n";
+			reasonText += " - Your API key is invalid\n";
+			reasonText += " - You just regenerated the key; wait a few seconds, then try again\n";
+			reasonText += " - You are trying to call a endpoint you dont have access to\n";
+			throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
+		}
+
+		case 404:
+		{
+			return new Pair<>(response.getResponseCode(), response.getResponseData());
+		}
+
+		case 405:
+		{
+			String reasonText = "The API was unable to handle your request due to the wrong HTTP method being used.\n";
+			throw new APIResponseException(APIHTTPErrorReason.ERROR_403, reasonText + response.getResponseData());
+		}
+		case 429:
+			if (response.getResponseData().startsWith(RateLimitType.LIMIT_UNDERLYING.getReason()) || response.getResponseData().startsWith(RateLimitType.LIMIT_SERVICE.getReason()))
+			{
+				return sleepAndRetry(retrys, response.getResponseCode());
+			} else
+			{
+				String error = response.getResponseData() + "429 ratelimit hit! " +
+						"Please do not restart your application to refresh the timer! " +
+						"This isn't supposed to happen unless you restarted your app before the last limit was hit!";
+
+				logger.error(error);
+
+			}
+
+			return this.build();
+
+		case 500:
+		case 502:
+		case 503:
+		case 504:
+		{
+			return sleepAndRetry(retrys, response.getResponseCode());
+		}
+
+		case 599:
+		{
+			throw new APIResponseException(APIHTTPErrorReason.ERROR_599, response.getResponseData());
+		}
+
+		default:
+		{
+			break;
+		}
+		}
+
+		System.err.println("UNHANDLED RESPONSE CODE!!!");
+		System.err.println("Response Code:" + response.getResponseCode());
+		System.err.println("Response Data:" + response.getResponseData());
+		throw new APINoValidResponseException(response.getResponseData());
+	}
+
+	private String postProcess(String returnValue)
+	{
+		final List<URLEndpoint> ddragon = Arrays.asList(URLEndpoint.DDRAGON_CHAMPION_MANY, URLEndpoint.DDRAGON_SUMMONER_SPELLS);
+		if (ddragon.contains(this.dc.getEndpoint()))
+		{
+			returnValue = postProcessDDragonMany(returnValue);
+		}
+
+		if (this.dc.getEndpoint() == URLEndpoint.DDRAGON_ITEMS || this.dc.getEndpoint() == URLEndpoint.DDRAGON_RUNES)
+		{
+			returnValue = postProcessDDragonAddId(returnValue);
+		}
+
+		final List<URLEndpoint> summonerEndpoints = Arrays.asList(
+				URLEndpoint.V4_SUMMONER_BY_ACCOUNT,
+				URLEndpoint.V4_SUMMONER_BY_ID,
+				URLEndpoint.V4_SUMMONER_BY_PUUID,
+				URLEndpoint.V1_TFT_SUMMONER_BY_ACCOUNT,
+				URLEndpoint.V1_TFT_SUMMONER_BY_ID,
+				URLEndpoint.V1_TFT_SUMMONER_BY_PUUID);
+		if (summonerEndpoints.contains(this.dc.getEndpoint()))
+		{
+			returnValue = postProcessSummoner(returnValue);
+		}
+
+		final List<URLEndpoint> apexEndpoints = Arrays.asList(URLEndpoint.V4_LEAGUE_MASTER, URLEndpoint.V4_LEAGUE_GRANDMASTER, URLEndpoint.V4_LEAGUE_CHALLENGER,
+				URLEndpoint.V1_TFT_LEAGUE_MASTER, URLEndpoint.V1_TFT_LEAGUE_GRANDMASTER, URLEndpoint.V1_TFT_LEAGUE_CHALLENGER);
+		if (apexEndpoints.contains(this.dc.getEndpoint()))
+		{
+			returnValue = postProcessApex(returnValue);
+		}
+
+		return returnValue;
+	}
+
+	private String postProcessApex(String returnValue)
+	{
+		JsonObject elem    = (JsonObject) JsonParser.parseString(returnValue);
+		JsonArray  entries = elem.getAsJsonArray("entries");
+		if (entries == null)
+		{
+			entries = new JsonArray();
+		}
+
+		entries.forEach(e -> {
+			JsonObject ob = (JsonObject) e;
+			ob.add("leagueId", elem.get("leagueId"));
+			ob.add("queueType", elem.get("queue"));
+			ob.add("tier", elem.get("tier"));
+		});
+
+		return Utils.getGson().toJson(elem);
+	}
+
+	private String postProcessDDragonMany(String returnValue)
+	{
+		JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
+		JsonObject parent = elem.getAsJsonObject("data");
+		for (String key : new HashSet<>(parent.keySet()))
+		{
+			JsonObject child = parent.getAsJsonObject(key);
+			String     id    = child.get("key").getAsString();
+			child.addProperty("key", key);
+			child.addProperty("id", id);
+			parent.add(id, child);
+			parent.remove(key);
+		}
+
+		return Utils.getGson().toJson(elem);
+	}
+
+	private String postProcessDDragonAddId(String returnValue)
+	{
+		JsonObject elem   = (JsonObject) JsonParser.parseString(returnValue);
+		JsonObject parent = elem.getAsJsonObject("data");
+		for (String key : new HashSet<>(parent.keySet()))
+		{
+			JsonObject child = parent.getAsJsonObject(key);
+			try 
+			{
+				int keyAsInt = Integer.parseInt(key);
+				child.addProperty("id", keyAsInt);
+
+			}   catch(NumberFormatException e) 
+			{
+				parent.remove(key);
+				logger.warn("Item/Rune received without a valid Id ({}), item removed from the list", key);
+			}
+		}
+
+		return Utils.getGson().toJson(elem);
+	}
+
+	private String postProcessPerkPath(String returnValue)
+	{
+		JsonObject elem     = (JsonObject) JsonParser.parseString(returnValue);
+		String     pathName = elem.get("name").getAsString();
+		String     pathId   = elem.get("id").getAsString();
+
+		JsonArray slots = elem.getAsJsonArray("slots");
+		for (JsonElement slot : slots)
+		{
+			JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
+			for (JsonElement rune : runes)
+			{
+				JsonObject obj = (JsonObject) rune;
+				obj.addProperty("runePathName", pathName);
+				obj.addProperty("runePathId", pathId);
+			}
+		}
+
+		return Utils.getGson().toJson(elem);
+	}
+
+	private String postProcessPerkPaths(String returnValue)
+	{
+		JsonArray element = (JsonArray) JsonParser.parseString(returnValue);
+
+		for (JsonElement elem : element)
+		{
+			String pathName = elem.getAsJsonObject().get("name").getAsString();
+			String pathId   = elem.getAsJsonObject().get("id").getAsString();
+
+			JsonArray slots = elem.getAsJsonObject().getAsJsonArray("slots");
+			for (JsonElement slot : slots)
+			{
+				JsonArray runes = slot.getAsJsonObject().getAsJsonArray("runes");
+				for (JsonElement rune : runes)
+				{
+					JsonObject obj = (JsonObject) rune;
+					obj.addProperty("runePathName", pathName);
+					obj.addProperty("runePathId", pathId);
+				}
+			}
+		}
+
+		return Utils.getGson().toJson(element);
+	}
+
+	private String postProcessSummoner(String returnValue)
+	{
+		JsonObject element = (JsonObject) JsonParser.parseString(returnValue);
+		element.addProperty("platform", this.dc.getPlatform().toString());
+		return Utils.getGson().toJson(element);
+	}
+
+	private Object sleepAndRetry(int[] retrys, int errorCode)
+	{
+		try
+		{
+			int  attempts           = (retrys != null && retrys.length == 1) ? ++retrys[0] : 1;
+			long nextSleepDuration  = attempts * 500L;
+			long totalSleepDuration = 0;
+			for (int i = 1; i < attempts; i++)
+			{
+				totalSleepDuration += i * 500L;
+			}
+
+
+			String message = "";
+			if (errorCode == 429)
+			{
+				message = "Ratelimit reached too many times, waiting " + nextSleepDuration / 1000 + " seconds then retrying";
+			} else
+			{
+				message = "Server error (" + errorCode + ") , waiting " + nextSleepDuration / 1000 + " seconds then retrying";
+			}
+
+			logger.info(message);
+
+			if (totalSleepDuration > this.dc.getMaxSleep())
+			{
+				throw new APINoValidResponseException(String.format("API did not return a valid response in time. Total sleep time is over the max sleep value %s > %s...\n" +
+						"Try setting `DataCall.setDefaultMaxSleep(long)` to a larger number (default is 10000)",
+						(nextSleepDuration + totalSleepDuration), this.dc.getMaxSleep()));
+			}
+
+			Thread.sleep(nextSleepDuration);
+			return this.build(attempts);
+		} catch (InterruptedException e)
+		{
+			throw new APINoValidResponseException("Something interupted the API timeout;" + e.getMessage());
+		}
+	}
+
+	public static final ReentrantLock lock = new ReentrantLock();
+
+	private void applyLimit(Enum platform, Enum endpoint)
+	{
+		lock.lock();
+		try
+		{
+			Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
+
+			if (child.get(endpoint) == null)
+			{
+				loadLimiterFromCache(platform, endpoint, child);
+			}
+		} finally
+		{
+			lock.unlock();
+		}
+
+		RateLimiter limitr = DataCall.getLimiter().getOrDefault(platform, new HashMap<>()).get(endpoint);
+
+		if (limitr != null)
+		{
+			limitr.acquire();
+			storeLimiter(platform, endpoint);
+		}
+	}
+
+	private void storeLimiter(Enum platform, Enum endpoint)
+	{
+		RateLimiter limiter  = DataCall.getLimiter().get(platform).get(endpoint);
+		String      baseKey  = platform.toString() + "/" + endpoint.toString();
+		String      limitKey = "limits/" + baseKey;
+		String      firstKey = "first/" + baseKey;
+		String      callKey  = "call/" + baseKey;
+
+		DataCall.getRatelimiterCache().put(firstKey, Utils.getGson().toJson(limiter.getFirstCallInTime()));
+		DataCall.getRatelimiterCache().put(callKey, Utils.getGson().toJson(limiter.getCallCountInTime()));
+	}
+
+	private void loadLimiterFromCache(Enum platform, Enum endpoint, Map<Enum, RateLimiter> child)
+	{
+		String baseKey  = platform.toString() + "/" + endpoint.toString();
+		String limitKey = "limits/" + baseKey;
+		String firstKey = "first/" + baseKey;
+		String callKey  = "call/" + baseKey;
+
+		String lastLimit = DataCall.getRatelimiterCache().get(limitKey, null);
+		String lastFirst = DataCall.getRatelimiterCache().get(firstKey, null);
+		String lastKey   = DataCall.getRatelimiterCache().get(callKey, null);
+
+		if (lastLimit == null)
+		{
+			logger.debug("No instance of an old ratelimiter found");
+			return;
+		} else
+		{
+			logger.debug("Loading old ratelimiter data");
+		}
+
+		try
+		{
+			List<RateLimit>            knownLimits = Utils.getGson().fromJson(lastLimit, new TypeToken<List<RateLimit>>() {}.getType());
+			Map<RateLimit, AtomicLong> knownTime   = Utils.getGson().fromJson(lastFirst, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
+			Map<RateLimit, AtomicLong> knownCount  = Utils.getGson().fromJson(lastKey, new TypeToken<Map<RateLimit, AtomicLong>>() {}.getType());
+
+
+			RateLimiter newerLimit = new BurstRateLimiter(knownLimits);
+			newerLimit.setCallCountInTime(knownCount);
+			newerLimit.setFirstCallInTime(knownTime);
+
+			logger.debug("Loaded ratelimit for {}", endpoint);
+
+			child.put(endpoint, newerLimit);
+			DataCall.getLimiter().put(platform, child);
+		} catch (JsonSyntaxException s)
+		{
+			try
+			{
+				logger.debug("Old ratelimiter was of incompatible type, re-creating");
+				DataCall.getRatelimiterCache().clear();
+				DataCall.getRatelimiterCache().sync();
+			} catch (BackingStoreException e)
+			{
+				e.printStackTrace();
+			}
+		}
+	}
+
+
+	/**
+	 * Opens a connection to the URL, then reads the data into a Response.
+	 *
+	 * @param url the URL to call
+	 * @return a DataCallResponse with the data from the call
+	 * @throws APINoValidResponseException if the datacall failed in any fashion
+	 */
+	private DataCallResponse getResponse(final String url)
+	{
+		final StringBuilder data = new StringBuilder();
+		try
+		{
+			final HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
+
+			con.setUseCaches(false);
+			con.setDefaultUseCaches(false);
+			con.setRequestProperty("User-Agent", "R4J");
+			con.setRequestProperty("Accept-Charset", "ISO-8859-1,utf-8");
+			con.setRequestProperty("Accept-Language", "en-US");
+			con.setRequestProperty("Cache-Control", "no-store,max-age=0,no-cache");
+			con.setRequestProperty("Expires", "0");
+			con.setRequestProperty("Pragma", "no-cache");
+			con.setRequestProperty("Connection", "keep-alive");
+			con.setRequestProperty("Content-Type", "application/json");
+			con.setConnectTimeout(this.dc.getConnectTimeout());
+			con.setReadTimeout(this.dc.getReadTimeout());
+			this.dc.getUrlHeaders().forEach(con::setRequestProperty);
+
+			if (requestMethod.equalsIgnoreCase("PATCH"))
+			{
+				con.setRequestProperty("X-HTTP-Method-Override", "PATCH");
+				con.setRequestMethod("POST");
+			} else
+			{
+				con.setRequestMethod(requestMethod);
+			}
+
+			StringBuilder sb = new StringBuilder();
+			con.getRequestProperties().forEach((key, value) -> sb.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
+
+			String printMe = new StringBuilder("\n")
+					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Url", url)).append("\n")
+					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Method", con.getRequestMethod())).append("\n")
+					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "POST data", this.postData)).append("\n")
+					.append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Request Headers", "")).append("\n")
+					.append(sb).toString();
+
+			//logger.debug(printMe);
+
+
+			if (null != this.postData && !this.postData.isEmpty())
+			{
+				con.setDoOutput(true);
+				final DataOutputStream writer = new DataOutputStream(con.getOutputStream());
+				writer.writeBytes(this.postData);
+				writer.flush();
+				writer.close();
+			}
+
+			con.connect();
+
+			StringBuilder sb2 = new StringBuilder("\n");
+			con.getHeaderFields().forEach((key, value) -> sb2.append(String.format(Constants.TABBED2X_VERBOSE_STRING_FORMAT, key, value)).append("\n"));
+
+			String printMe2 = new StringBuilder("\n").append(String.format(Constants.TABBED_VERBOSE_STRING_FORMAT, "Response Headers", ""))
+					.append(sb2)
+					.toString();
+			//logger.debug(printMe2);
+
+
+			String appA    = con.getHeaderField("X-App-Rate-Limit");
+			String appB    = con.getHeaderField("X-App-Rate-Limit-Count");
+			String methodA = con.getHeaderField("X-Method-Rate-Limit");
+			String methodB = con.getHeaderField("X-Method-Rate-Limit-Count");
+
+			if (appA == null)
+			{
+				logger.debug("Header 'X-App-Rate-Limit' missing from call: {} ", getURL());
+			} else
+			{
+				lock.lock();
+				createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
+				saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
+				lock.unlock();
+			}
+
+			if (methodA == null)
+			{
+				logger.debug("Header 'X-Method-Rate-Limit' missing from call: {}", getURL());
+			} else
+			{
+				lock.lock();
+				createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
+				saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
+				lock.unlock();
+			}
+
+			String deprecationHeader = con.getHeaderField("X-Riot-Deprecated");
+			if (deprecationHeader != null)
+			{
+				LocalDateTime timeout = LocalDateTime.ofEpochSecond(Long.parseLong(deprecationHeader) / 1000, 0, ZoneOffset.ofHours(-7));
+				logger.info("You are using a deprecated method, this method will stop working at: {}", timeout);
+			}
+
+			if (con.getResponseCode() == 429)
+			{
+				final RateLimitType limitType = RateLimitType.getBestMatch(con.getHeaderField("X-Rate-Limit-Type"));
+
+				StringBuilder valueList = new StringBuilder();
+				DataCall.getLimiter().get(dc.getPlatform()).forEach((key, value) -> {
+					valueList.append(key);
+					valueList.append("=");
+					valueList.append(value.getCallCountInTime());
+					valueList.append("\n");
+				});
+
+				String reasonString = String.format("%s%n%s", limitType.getReason(), valueList.toString().trim());
+				String reason       = String.format("%s%n", reasonString);
+
+				if (limitType == RateLimitType.LIMIT_METHOD)
+				{
+					RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getEndpoint());
+					limter.updateSleep(con.getHeaderField("Retry-After"));
+				}
+
+				if (limitType == RateLimitType.LIMIT_USER)
+				{
+
+					RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getPlatform());
+					limter.updateSleep(con.getHeaderField("Retry-After"));
+				}
+
+				return new DataCallResponse(con.getResponseCode(), reason);
+			}
+
+			if (con.getResponseCode() == 204)
+			{
+				return new DataCallResponse(con.getResponseCode(), "");
+			}
+
+			InputStream stream = (con.getResponseCode() <= 399) ? con.getInputStream() : con.getErrorStream();
+
+			if (stream == null)
+			{
+				return new DataCallResponse(con.getResponseCode(), "Unable to read stream!");
+			}
+
+			try (BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8)))
+			{
+				br.lines().forEach(data::append);
+			}
+
+			con.disconnect();
+
+			return new DataCallResponse(con.getResponseCode(), data.toString());
+		} catch (final IOException e)
+		{
+			throw new APIResponseException(APIHTTPErrorReason.ERROR_599, APIHTTPErrorReason.ERROR_599.getReason());
+		}
+	}
+
+	private void createRatelimiterIfMissing(String methodA, Enum platform, Enum endpoint)
+	{
+		Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
+
+		RateLimiter oldLimit   = child.get(endpoint);
+		RateLimiter newerLimit = createLimiter(methodA);
+
+		if (!newerLimit.equals(oldLimit))
+		{
+			newerLimit.mergeFrom(oldLimit);
+			child.put(endpoint, newerLimit);
+
+			logger.debug("Updating Ratelimit For {}", endpoint);
+			logger.debug(newerLimit.getLimits().toString());
+		}
+
+		DataCall.getLimiter().put(platform, child);
+	}
+
+	private void saveHeaderRateLimit(String limitCount, Enum platform, Enum endpoint)
+	{
+		Map<Enum, Map<Integer, Integer>> parent = DataCall.getCallData().getOrDefault(platform, new HashMap<>());
+		Map<Integer, Integer>            child  = parent.getOrDefault(endpoint, new HashMap<>());
+
+		child.putAll(parseLimitFromHeader(limitCount));
+		parent.put(endpoint, child);
+		DataCall.getCallData().put(platform, parent);
+
+		updateRatelimiter(platform, endpoint);
+		storeLimiter(platform, endpoint);
+	}
+
+	private Map<Integer, Integer> parseLimitFromHeader(String headerValue)
+	{
+		final String[]        limits  = headerValue.split(",");
+		Map<Integer, Integer> timeout = new HashMap<>();
+		for (final String limitPair : limits)
+		{
+			final String[] limit = limitPair.split(":");
+			final Integer  call  = Integer.parseInt(limit[0]);
+			final Integer  time  = Integer.parseInt(limit[1]);
+			timeout.put(time, call);
+		}
+
+		return timeout;
+	}
+
+	public RateLimiter createLimiter(String limitCount)
+	{
+		Map<Integer, Integer> timeout = parseLimitFromHeader(limitCount);
+
+		List<RateLimit> limits = new ArrayList<>();
+		for (Entry<Integer, Integer> entry : timeout.entrySet())
+		{
+			limits.add(new RateLimit(entry.getValue(), entry.getKey(), TimeUnit.SECONDS));
+		}
+
+		return new BurstRateLimiter(limits);
+	}
+
+	/**
+	 * Generates the URL to use for the call.
+	 *
+	 * @return the URL to use for the call.
+	 */
+	private String getURL()
+	{
+		String[] url = {dc.getProxy()};
+		if (dc.getEndpoint() != null)
+		{
+			url[0] = url[0].replace(Constants.GAME_PLACEHOLDER, dc.getEndpoint().getGame());
+			url[0] = url[0].replace(Constants.SERVICE_PLACEHOLDER, dc.getEndpoint().getService());
+			url[0] = url[0].replace(Constants.VERSION_PLACEHOLDER, dc.getEndpoint().getVersion());
+			url[0] = url[0].replace(Constants.RESOURCE_PLACEHOLDER, dc.getEndpoint().getResource());
+		}
+		if (dc.getPlatform() != null)
+		{
+			url[0] = url[0].replace(Constants.PLATFORM_PLACEHOLDER, dc.getPlatform().toString().toLowerCase());
+			url[0] = url[0].replace(Constants.REGION_PLACEHOLDER, ((RealmSpesificEnum) dc.getPlatform()).getRealmValue());
+		}
+		dc.getUrlParams().forEach((k, v) -> url[0] = url[0].replace(k, v));
+
+		boolean first = true;
+		for (Entry<String, String> pair : dc.getUrlData().entrySet())
+		{
+			char token = first ? '?' : '&';
+
+			if (first)
+			{
+				first = !first;
+			}
+
+			url[0] = url[0] + token + pair.getKey() + '=' + pair.getValue();
+		}
+
+		return url[0];
+	}
+
+
+	/**
+	 * Sets the endpoint to make the call to
+	 *
+	 * @param endpoint the endpoint to make the call to
+	 * @return this
+	 */
+	public DataCallBuilder withEndpoint(final URLEndpoint endpoint)
+	{
+		this.dc.setEndpoint(endpoint);
+		return this;
+	}
+
+	/**
+	 * enables ratelimiters for this call
+	 *
+	 * @param flag enabled or disabled
+	 * @return this
+	 */
+	public DataCallBuilder withLimiters(final boolean flag)
+	{
+		this.dc.setUseLimiters(flag);
+		return this;
+	}
+
+	/**
+	 * Sets the headers to use with the call
+	 *
+	 * @param key   the header key
+	 * @param value the header value
+	 * @return this
+	 */
+	public DataCallBuilder withHeader(final String key, final String value)
+	{
+		this.dc.getUrlHeaders().merge(key, value, MERGE);
+		return this;
+	}
+
+	/**
+	 * Sets the data to send with the request if its a POST call
+	 *
+	 * @param data the data to send
+	 * @return this
+	 */
+	public DataCallBuilder withPostData(final String data)
+	{
+		this.postData = data;
+		return this;
+	}
+
+
+	/**
+	 * The request-method on the call (usually GET or POST)
+	 *
+	 * @param method the request method
+	 * @return this
+	 */
+	public DataCallBuilder withRequestMethod(final String method)
+	{
+		this.requestMethod = method;
+		return this;
+	}
+
+	/**
+	 * Set the platform to make this call to. (ie. EUW1)
+	 *
+	 * @param server the server to make the call to
+	 * @return this
+	 */
+	public DataCallBuilder withPlatform(final Enum server)
+	{
+		this.dc.setPlatform(server);
+		return this;
+	}
+
+	/**
+	 * Replaces placeholders in the URL (ie. {region})
+	 *
+	 * @param key   The key to replace (ie. {region})
+	 * @param value The data to replace it with (ie. EUW)
+	 * @return this
+	 */
+	public DataCallBuilder withURLDataAsSet(final String key, final String value)
+	{
+		this.dc.getUrlData().merge(key, (this.dc.getUrlData().get(key) != null) ? ("&" + key + "=" + value) : value, MERGE_AS_SET);
+		return this;
+	}
+
+
+	/**
+	 * Adds parameters to the url (ie. ?api_key)
+	 *
+	 * @param key   the parameter to add (ie. api_key)
+	 * @param value the value to add after the parameter (ie. 6fa459ea-ee8a-3ca4-894e-db77e160355e)
+	 * @return this
+	 */
+	public DataCallBuilder withQueryParameter(final String key, final String value)
+	{
+		this.dc.getUrlData().merge(key, value, MERGE);
+		return this;
+	}
+
+	/**
+	 * Replaces placeholders in the URL (ie. {region})
+	 *
+	 * @param key   The key to replace (ie. {region})
+	 * @param value The data to replace it with (ie. EUW)
+	 * @return this
+	 */
+	public DataCallBuilder withURLParameter(final String key, final String value)
+	{
+		this.dc.getUrlParams().merge(key, value, MERGE);
+		return this;
+	}
+
+	public DataCallBuilder withProxy(String proxy)
+	{
+		this.dc.setProxy(proxy);
+		return this;
+	}
 }

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -42,8 +42,6 @@ public class DataCallBuilder
 	private String postData      = "";
 
 	private Semaphore semaphore = new Semaphore(NUMBER_OF_CALLS_ALLOWED_IN_ASYNC, true);
-
-	private static final Lock lock = new ReentrantLock();
 	
 	private static final Map<Enum, Lock> lockContainer = new HashMap<>();
 	
@@ -420,7 +418,7 @@ public class DataCallBuilder
 
 	private void applyLimit(Enum platform, Enum endpoint)
 	{
-		lock.lock();
+		getLock(platform).lock();
 		try
 		{
 			Map<Enum, RateLimiter> child = DataCall.getLimiter().getOrDefault(platform, new HashMap<>());
@@ -431,7 +429,7 @@ public class DataCallBuilder
 			}
 		} finally
 		{
-			lock.unlock();
+			getLock(platform).unlock();
 		}
 		
 		RateLimiter limitr = DataCall.getLimiter().getOrDefault(platform, new HashMap<>()).get(endpoint);
@@ -586,11 +584,11 @@ public class DataCallBuilder
 			} else
 			{
 				try {
-					lock.lock();
+					getLock(dc.getPlatform()).lock();
 					createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
 					saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
 				}finally {
-					lock.unlock();
+					getLock(dc.getPlatform()).unlock();
 				}
 			}
 
@@ -600,11 +598,11 @@ public class DataCallBuilder
 			} else
 			{
 				try {
-					lock.lock();
+					getLock(dc.getPlatform()).lock();
 					createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
 					saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
 				} finally {
-					lock.unlock();
+					getLock(dc.getPlatform()).unlock();
 				}
 			}
 

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -610,14 +610,13 @@ public class DataCallBuilder
                 {
                     RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getEndpoint());
                     limter.updateSleep(con.getHeaderField("Retry-After"));
-                    limter.resetCalls();
                 }
                 
                 if (limitType == RateLimitType.LIMIT_USER)
                 {
+                	
                     RateLimiter limter = DataCall.getLimiter().get(this.dc.getPlatform()).get(this.dc.getPlatform());
                     limter.updateSleep(con.getHeaderField("Retry-After"));
-                    limter.resetCalls();
                 }
                 
                 return new DataCallResponse(con.getResponseCode(), reason);

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -44,6 +44,8 @@ public class DataCallBuilder
 	private Semaphore semaphore = new Semaphore(NUMBER_OF_CALLS_ALLOWED_IN_ASYNC, true);
 
 	private static final Map<Enum, Lock> lockContainer = new HashMap<>();
+	
+	private static final Lock globalLock = new ReentrantLock();
 
 	private static final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager()
 	{
@@ -608,12 +610,12 @@ public class DataCallBuilder
 			} else
 			{
 				try {
-					getLock(dc.getPlatform()).lock(); // app level -> platform
+					globalLock.lock(); // app level -> platform
 					createRatelimiterIfMissing(appA, dc.getPlatform(), dc.getPlatform());
 					//Since it's behind a lock, we can't update the app limit here if we are not sure that we are still in the same time period
 					//saveHeaderRateLimit(appB, dc.getPlatform(), dc.getPlatform());
 				}finally {
-					getLock(dc.getPlatform()).unlock();
+					globalLock.unlock();
 				}
 			}
 
@@ -623,12 +625,12 @@ public class DataCallBuilder
 			} else
 			{
 				try {
-					getLock(dc.getEndpoint()).lock(); // method level -> endpoint
+					globalLock.lock(); // method level -> endpoint
 					createRatelimiterIfMissing(methodA, dc.getPlatform(), dc.getEndpoint());
 					//Since it's behind a lock, we can't update the app limit here if we are not sure that we are still in the same time period
 					//saveHeaderRateLimit(methodB, dc.getPlatform(), dc.getEndpoint());
 				} finally {
-					getLock(dc.getEndpoint()).unlock();
+					globalLock.unlock();
 				}
 			}
 

--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameModeType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameModeType.java
@@ -102,6 +102,11 @@ public enum GameModeType implements CodedEnum
      */
     CHERRY,
     
+	/**
+	 * 5v5 Brawl
+	 */
+    BRAWL,
+    
     /**
      * TFT
      */

--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
@@ -372,6 +372,11 @@ public enum GameQueueType implements CodedEnum
     CHERRY(1700, 1701, 1704, 1710),
     
     /**
+     * 5v5 Brawl
+     */
+    BRAWL(2300, 2301, 2302, 2303, 2304, 2305),
+    
+    /**
      * Ultra Rapid Fire games
      */
     URF_1V1(1901),

--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/MapType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/MapType.java
@@ -85,7 +85,12 @@ public enum MapType implements CodedEnum
      * Strawberry map
      */
     STRAWBERRY(33, new Rectangle(0, 0, 12056, 12056)),
-    ;
+    
+	/**
+	 * Brawl map
+     */
+	BRAWL(35, new Rectangle(0, 0, 12056, 12056)),
+	;
     
     
     private final Integer   mapId;

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -2,6 +2,8 @@ package no.stelar7.api.r4j.basic.ratelimiting;
 
 
 import no.stelar7.api.r4j.basic.calling.DataCall;
+import no.stelar7.api.r4j.basic.calling.DataCallBuilder;
+
 import org.slf4j.*;
 
 import java.time.*;
@@ -27,7 +29,7 @@ public class BurstRateLimiter extends RateLimiter
     public void acquire()
     {
     	long sleepTime = 0;
-        lock.lock();
+        DataCallBuilder.lock.lock();
         try
         {
             update();
@@ -35,7 +37,7 @@ public class BurstRateLimiter extends RateLimiter
 
         } finally
         {
-            lock.unlock();
+        	DataCallBuilder.lock.unlock();
         }
         
         if (sleepTime != 0)
@@ -67,7 +69,7 @@ public class BurstRateLimiter extends RateLimiter
     @Override
     public void updatePermitsTakenPerX(Map<Integer, Integer> data)
     {
-    	lock.lock();
+    	DataCallBuilder.lock.lock();
     	try 
     	{
 	        for (Entry<Integer, Integer> key : data.entrySet())
@@ -88,7 +90,7 @@ public class BurstRateLimiter extends RateLimiter
 	        }
 		} finally 
     	{
-			lock.unlock();
+			DataCallBuilder.lock.unlock();
 		}
         
     }

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -93,7 +93,7 @@ public class BurstRateLimiter extends RateLimiter
 			long actualCountCall = callCountInTime.get(limit).incrementAndGet();
 
 			// ACTUAL CHECK IF WE ARE OVER THE LIMIT
-			if (actualCountCall >= limit.getPermits()) { // We add 10 query as security margin, test
+			if (actualCountCall + 10 >= limit.getPermits()) { // We add 10 query as security margin, test
 				
 				// We need to wait for the next sliding window to make our request
 				long delayForNextWindow = firstCallInTime.get(limit).get() + limit.getTimeframeInMS() - now.toEpochMilli();

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -43,7 +43,7 @@ public class BurstRateLimiter extends RateLimiter
             Duration dur = Duration.of(sleepTime, ChronoUnit.MILLIS);
             
             StringBuilder sb = new StringBuilder();
-            sb.append("Ratelimited activated! Sleeping for: {}".formatted(dur));
+            sb.append(String.format("Ratelimited activated! Sleeping for: %s", dur.toString()));
             sb.append("Callstack:");
             Arrays.stream(Thread.currentThread().getStackTrace())
                   .skip(DataCall.getCallStackSkip())

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -26,10 +26,10 @@ public class BurstRateLimiter extends RateLimiter
 	}
 
 	@Override
-	public void acquire(Enum platform)
+	public void acquire(Enum platformOrEndpoint)
 	{
 		long sleepTime = 0;
-		DataCallBuilder.getLock(platform).lock();
+		DataCallBuilder.getLock(platformOrEndpoint).lock();
 		try
 		{	
 			overloadTimerLock.lock();
@@ -45,7 +45,7 @@ public class BurstRateLimiter extends RateLimiter
 				Duration dur = Duration.of(sleepTime, ChronoUnit.MILLIS);
 
 				StringBuilder sb = new StringBuilder();
-				sb.append(String.format("Ratelimited activated! Sleeping for: %s%n", dur.toString()));
+				sb.append(String.format("Ratelimited activated for {} ! Sleeping for: %s%n", platformOrEndpoint.name(), dur.toString()));
 				sb.append("Callstack:\n");
 				Arrays.stream(Thread.currentThread().getStackTrace())
 				.skip(DataCall.getCallStackSkip())
@@ -66,14 +66,14 @@ public class BurstRateLimiter extends RateLimiter
 			}
 		} finally
 		{
-			DataCallBuilder.getLock(platform).unlock();
+			DataCallBuilder.getLock(platformOrEndpoint).unlock();
 		}
 	}
 
 	@Override
-	public void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platform)
+	public void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platformOrEndpoint)
 	{
-		DataCallBuilder.getLock(platform).lock();
+		DataCallBuilder.getLock(platformOrEndpoint).lock();
 		try 
 		{
 			for (Entry<Integer, Integer> key : data.entrySet())
@@ -94,7 +94,7 @@ public class BurstRateLimiter extends RateLimiter
 			}
 		} finally 
 		{
-			DataCallBuilder.getLock(platform).unlock();
+			DataCallBuilder.getLock(platformOrEndpoint).unlock();
 		}
 
 	}

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -131,7 +131,7 @@ public class BurstRateLimiter extends RateLimiter
         
         if (delay[0] != 0)
         {
-            delay[0] = (long) ((Math.ceil(delay[0] / 1000f) + bias) * (1000L * multiplicativeBias));
+            delay[0] = (long) ((Math.ceil(delay[0] / 1000f) + bias) * (1000L * multiplicativeBias)) + 1000L; // Add 1 second to the delay to ensure we don't hit the limit again immediately, test
         }
         
         return delay[0];

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -42,12 +42,16 @@ public class BurstRateLimiter extends RateLimiter
         {
             Duration dur = Duration.of(sleepTime, ChronoUnit.MILLIS);
             
-            logger.info("Ratelimited activated! Sleeping for: {}", dur);
-            logger.info("Callstack:");
+            StringBuilder sb = new StringBuilder();
+            sb.append("Ratelimited activated! Sleeping for: {}".formatted(dur));
+            sb.append("Callstack:");
             Arrays.stream(Thread.currentThread().getStackTrace())
                   .skip(DataCall.getCallStackSkip())
                   .limit(DataCall.getCallStackLimit())
-                  .forEachOrdered(s -> logger.info(s.toString()));
+                  .forEachOrdered(s -> sb.append(s.toString()));
+            
+            String message = sb.toString();
+            logger.warn(message);
         }
         
         try 

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -100,6 +100,11 @@ public class BurstRateLimiter extends RateLimiter
 		int     multiplicativeBias = 1;
 		Instant now                = Instant.now();
 		long[]  delay              = {overloadTimer * 1000L};
+		
+		if(delay[0] != 0) {
+			delay[0] = overloadReceivedTime.toEpochMilli() + delay[0] - now.toEpochMilli(); // We remove the time that has already passed since the overload was received
+		}
+		
 		overloadTimer = 0;
 
 		if (delay[0] == 0)
@@ -144,7 +149,7 @@ public class BurstRateLimiter extends RateLimiter
 			AtomicLong firstCall = firstCallInTime.computeIfAbsent(limit, (key) -> new AtomicLong(0));
 			AtomicLong counter = callCountInTime.computeIfAbsent(limit, (key) -> new AtomicLong(0));
 
-			if ((firstCall.get() - now.toEpochMilli()) + limit.getTimeframeInMS() < 0)
+			if ((firstCall.get()+10 - now.toEpochMilli()) + limit.getTimeframeInMS() < 0)
 			{
 				firstCallInTime.get(limit).set(now.toEpochMilli());
 				callCountInTime.get(limit).set(0);

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -108,7 +108,7 @@ public class BurstRateLimiter extends RateLimiter
             for (RateLimit limit : limits)
             {
                 long actual = callCountInTime.get(limit).get();
-                if (actual >= limit.getPermits())
+                if (actual + 10 >= limit.getPermits()) // We add 10 query as security margin, test
                 {
                     
                     logger.debug("Calls made in the time frame: {}", actual);

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -43,15 +43,15 @@ public class BurstRateLimiter extends RateLimiter
             Duration dur = Duration.of(sleepTime, ChronoUnit.MILLIS);
             
             StringBuilder sb = new StringBuilder();
-            sb.append(String.format("Ratelimited activated! Sleeping for: %s", dur.toString()));
-            sb.append("Callstack:");
+            sb.append(String.format("Ratelimited activated! Sleeping for: %s%n", dur.toString()));
+            sb.append("Callstack:\n");
             Arrays.stream(Thread.currentThread().getStackTrace())
                   .skip(DataCall.getCallStackSkip())
                   .limit(DataCall.getCallStackLimit())
-                  .forEachOrdered(s -> sb.append(s.toString()));
+                  .forEachOrdered(s -> sb.append(s.toString() + "\n"));
             
             String message = sb.toString();
-            logger.warn(message);
+            logger.debug(message);
         }
         
         try 

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -17,144 +17,143 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class BurstRateLimiter extends RateLimiter
 {
-    
-    private static final Logger logger = LoggerFactory.getLogger(BurstRateLimiter.class);
-        
-    public BurstRateLimiter(List<RateLimit> limits)
-    {
-        super(limits.toArray(new RateLimit[0]));
-    }
-    
-    @Override
-    public void acquire()
-    {
-    	long sleepTime = 0;
-        DataCallBuilder.lock.lock();
-        try
-        {
-            update();
-            sleepTime = getDelay();
 
-        } finally
-        {
-        	DataCallBuilder.lock.unlock();
-        }
-        
-        if (sleepTime != 0)
-        {
-            Duration dur = Duration.of(sleepTime, ChronoUnit.MILLIS);
-            
-            StringBuilder sb = new StringBuilder();
-            sb.append(String.format("Ratelimited activated! Sleeping for: %s%n", dur.toString()));
-            sb.append("Callstack:\n");
-            Arrays.stream(Thread.currentThread().getStackTrace())
-                  .skip(DataCall.getCallStackSkip())
-                  .limit(DataCall.getCallStackLimit())
-                  .forEachOrdered(s -> sb.append(s.toString() + "\n"));
-            
-            String message = sb.toString();
-            logger.debug(message);
-        }
-        
-        try 
-        {
-        	Thread.sleep(sleepTime);
-        }catch (InterruptedException e)
-        {
-        	logger.error("Thread interrupted while sleeping", e);
-            Thread.currentThread().interrupt();
-        }
-    }
-    
-    @Override
-    public void updatePermitsTakenPerX(Map<Integer, Integer> data)
-    {
-    	DataCallBuilder.lock.lock();
-    	try 
-    	{
-	        for (Entry<Integer, Integer> key : data.entrySet())
-	        {
-	            for (RateLimit l : limits)
-	            {
-	                if (l.getTimeframeInMS() / 1000 == key.getKey())
-	                {
-	                    long oldVal = callCountInTime.get(l).get();
-	                    long newVal = key.getValue();
-	                    if (oldVal < newVal)
-	                    {
-	                        callCountInTime.get(l).set(newVal);
-	                        logger.debug("limit {} has changed from {} to {}", key, oldVal, newVal);
-	                    }
-	                }
-	            }
-	        }
-		} finally 
-    	{
-			DataCallBuilder.lock.unlock();
+	private static final Logger logger = LoggerFactory.getLogger(BurstRateLimiter.class);
+
+	public BurstRateLimiter(List<RateLimit> limits)
+	{
+		super(limits.toArray(new RateLimit[0]));
+	}
+
+	@Override
+	public void acquire(Enum platform)
+	{
+		long sleepTime = 0;
+		DataCallBuilder.getLock(platform).lock();
+		try
+		{
+			update();
+			sleepTime = getDelay();
+
+			if (sleepTime != 0)
+			{
+				Duration dur = Duration.of(sleepTime, ChronoUnit.MILLIS);
+
+				StringBuilder sb = new StringBuilder();
+				sb.append(String.format("Ratelimited activated! Sleeping for: %s%n", dur.toString()));
+				sb.append("Callstack:\n");
+				Arrays.stream(Thread.currentThread().getStackTrace())
+				.skip(DataCall.getCallStackSkip())
+				.limit(DataCall.getCallStackLimit())
+				.forEachOrdered(s -> sb.append(s.toString() + "\n"));
+
+				String message = sb.toString();
+				logger.debug(message);
+			}
+
+			try 
+			{
+				Thread.sleep(sleepTime);
+			}catch (InterruptedException e)
+			{
+				logger.error("Thread interrupted while sleeping", e);
+				Thread.currentThread().interrupt();
+			}
+		} finally
+		{
+			DataCallBuilder.getLock(platform).unlock();
 		}
-        
-    }
-    
-    private long getDelay()
-    {
-        int     bias               = 1;
-        int     multiplicativeBias = 1;
-        Instant now                = Instant.now();
-        long[]  delay              = {overloadTimer * 1000L};
-        overloadTimer = 0;
-        
-        if (delay[0] == 0)
-        {
-            for (RateLimit limit : limits)
-            {
-                long actual = callCountInTime.get(limit).get();
-                if (actual + 10 >= limit.getPermits()) // We add 10 query as security margin, test
-                {
-                    
-                    logger.debug("Calls made in the time frame: {}", actual);
-                    logger.debug("Limit for the time frame: {}", limit.getPermits());
-                    
-                    int newBias = (int) Math.floorDiv(actual, (long) limit.getPermits());
-                    if (newBias > multiplicativeBias)
-                    {
-                        multiplicativeBias = newBias;
-                    }
-                    
-                    long newDelay = firstCallInTime.get(limit).get() + limit.getTimeframeInMS() - now.toEpochMilli();
-                    if (newDelay > delay[0])
-                    {
-                        delay[0] = newDelay;
-                    }
-                }
-            }
-        }
-        
-        if (delay[0] != 0)
-        {
-            delay[0] = (long) ((Math.ceil(delay[0] / 1000f) + bias) * (1000L * multiplicativeBias)) + 1000L; // Add 1 second to the delay to ensure we don't hit the limit again immediately, test
-        }
-        
-        return delay[0];
-    }
-    
-    private void update()
-    {
-        Instant now = Instant.now();
-        for (RateLimit limit : limits)
-        {
-            AtomicLong firstCall = firstCallInTime.computeIfAbsent(limit, (key) -> new AtomicLong(0));
-            AtomicLong counter = callCountInTime.computeIfAbsent(limit, (key) -> new AtomicLong(0));
-            
-            if ((firstCall.get() - now.toEpochMilli()) + limit.getTimeframeInMS() < 0)
-            {
-                firstCallInTime.get(limit).set(now.toEpochMilli());
-                callCountInTime.get(limit).set(0);
-            }
-            
-            callCountInTime.get(limit).incrementAndGet();
-            
-            logger.debug("{}: current call count: {}", limit, callCountInTime.get(limit));
-        }
-    }
-    
+	}
+
+	@Override
+	public void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platform)
+	{
+		DataCallBuilder.getLock(platform).lock();
+		try 
+		{
+			for (Entry<Integer, Integer> key : data.entrySet())
+			{
+				for (RateLimit l : limits)
+				{
+					if (l.getTimeframeInMS() / 1000 == key.getKey())
+					{
+						long oldVal = callCountInTime.get(l).get();
+						long newVal = key.getValue();
+						if (oldVal < newVal)
+						{
+							callCountInTime.get(l).set(newVal);
+							logger.debug("limit {} has changed from {} to {}", key, oldVal, newVal);
+						}
+					}
+				}
+			}
+		} finally 
+		{
+			DataCallBuilder.getLock(platform).unlock();
+		}
+
+	}
+
+	private long getDelay()
+	{
+		int     bias               = 1;
+		int     multiplicativeBias = 1;
+		Instant now                = Instant.now();
+		long[]  delay              = {overloadTimer * 1000L};
+		overloadTimer = 0;
+
+		if (delay[0] == 0)
+		{
+			for (RateLimit limit : limits)
+			{
+				long actual = callCountInTime.get(limit).get();
+				if (actual + 10 >= limit.getPermits()) // We add 10 query as security margin, test
+				{
+
+					logger.debug("Calls made in the time frame: {}", actual);
+					logger.debug("Limit for the time frame: {}", limit.getPermits());
+
+					int newBias = (int) Math.floorDiv(actual, (long) limit.getPermits());
+					if (newBias > multiplicativeBias)
+					{
+						multiplicativeBias = newBias;
+					}
+
+					long newDelay = firstCallInTime.get(limit).get() + limit.getTimeframeInMS() - now.toEpochMilli();
+					if (newDelay > delay[0])
+					{
+						delay[0] = newDelay;
+					}
+				}
+			}
+		}
+
+		if (delay[0] != 0)
+		{
+			delay[0] = (long) ((Math.ceil(delay[0] / 1000f) + bias) * (1000L * multiplicativeBias)) + 1000L; // Add 1 second to the delay to ensure we don't hit the limit again immediately, test
+		}
+
+		return delay[0];
+	}
+
+	private void update()
+	{
+		Instant now = Instant.now();
+		for (RateLimit limit : limits)
+		{
+			AtomicLong firstCall = firstCallInTime.computeIfAbsent(limit, (key) -> new AtomicLong(0));
+			AtomicLong counter = callCountInTime.computeIfAbsent(limit, (key) -> new AtomicLong(0));
+
+			if ((firstCall.get() - now.toEpochMilli()) + limit.getTimeframeInMS() < 0)
+			{
+				firstCallInTime.get(limit).set(now.toEpochMilli());
+				callCountInTime.get(limit).set(0);
+			}
+
+			callCountInTime.get(limit).incrementAndGet();
+
+			logger.debug("{}: current call count: {}", limit, callCountInTime.get(limit));
+		}
+	}
+
 }

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/CounterRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/CounterRateLimiter.java
@@ -1,0 +1,46 @@
+package no.stelar7.api.r4j.basic.ratelimiting;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import no.stelar7.api.r4j.basic.calling.DataCallBuilder;
+
+/**
+ * 
+ */
+public class CounterRateLimiter extends RateLimiter {
+
+	public CounterRateLimiter() {
+		super(new RateLimit(999999, 99999, TimeUnit.DAYS)); // We use a very high limit to only count, this count will be transfered when limit are known
+	}
+	
+	@Override
+	public void acquire(Enum platformOrEndpoint) {
+		DataCallBuilder.getLock(platformOrEndpoint).lock();
+		try {
+			for (RateLimit limit : limits)
+			{
+				firstCallInTime.computeIfAbsent(limit, (key) -> new AtomicLong(Instant.now().toEpochMilli()));
+				callCountInTime.computeIfAbsent(limit, (key) -> new AtomicLong(0)).incrementAndGet();
+			}
+		}finally {
+			DataCallBuilder.getLock(platformOrEndpoint).unlock();
+		}
+	}
+	
+	public RateLimit getDummyLimit() {
+		for (RateLimit limit : limits)
+		{
+			return limit;
+		}
+		return null;
+	}
+
+	@Override
+	public void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platformOrEndpoint) {
+		// Do nothing, as this is a counter rate limiter
+	}
+
+}

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimit.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimit.java
@@ -9,7 +9,7 @@ public class RateLimit
     
     public RateLimit(final int permits, final long time, final TimeUnit unit)
     {
-        this.permits = (int) (permits * 0.9); // Add a 10% safety net
+        this.permits = permits;
         delayInMs = unit.toMillis(time);
     }
     

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimit.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimit.java
@@ -9,7 +9,7 @@ public class RateLimit
     
     public RateLimit(final int permits, final long time, final TimeUnit unit)
     {
-        this.permits = permits;
+        this.permits = (int) (permits * 0.9); // Add a 10% safety net
         delayInMs = unit.toMillis(time);
     }
     

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
@@ -138,8 +138,8 @@ public abstract class RateLimiter
 			if(oldLimit instanceof CounterRateLimiter) {
 				CounterRateLimiter toConvert = (CounterRateLimiter) oldLimit;
 				for(RateLimit limit : limits) {
-					firstCallInTime.put(limit, oldLimit.getFirstCallInTime().get(toConvert.getDummyLimit()));
-					callCountInTime.put(limit, oldLimit.getCallCountInTime().get(toConvert.getDummyLimit()));
+					firstCallInTime.put(limit, new AtomicLong(oldLimit.getFirstCallInTime().get(toConvert.getDummyLimit()).get()));
+					callCountInTime.put(limit, new AtomicLong(oldLimit.getCallCountInTime().get(toConvert.getDummyLimit()).get()));
 				}
 				
 				this.overloadTimer = oldLimit.overloadTimer;
@@ -174,5 +174,10 @@ public abstract class RateLimiter
 	public void setFirstCallInTime(Map<RateLimit, AtomicLong> firstCallInTime)
 	{
 		this.firstCallInTime = firstCallInTime;
+	}
+	
+	public static Lock getOverloadTimerLock()
+	{
+		return overloadTimerLock;
 	}
 }

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
@@ -134,6 +134,18 @@ public abstract class RateLimiter
 	{
 		if (oldLimit != null)
 		{
+			
+			if(oldLimit instanceof CounterRateLimiter toConvert) {
+				for(RateLimit limit : limits) {
+					firstCallInTime.put(limit, oldLimit.getFirstCallInTime().get(toConvert.getDummyLimit()));
+					callCountInTime.put(limit, oldLimit.getCallCountInTime().get(toConvert.getDummyLimit()));
+				}
+				
+				this.overloadTimer = oldLimit.overloadTimer;
+				this.overloadReceivedTime = oldLimit.overloadReceivedTime;
+				return;
+			}
+			
 			oldLimit.getCallCountInTime().forEach((key, value) -> {
 				if (callCountInTime.containsKey(key))
 				{

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
@@ -7,38 +7,41 @@ import no.stelar7.api.r4j.basic.calling.DataCallBuilder;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class RateLimiter
 {
-    
-    protected List<RateLimit>            limits;
-    protected Map<RateLimit, AtomicLong> firstCallInTime;
-    protected Map<RateLimit, AtomicLong> callCountInTime;
-        
-    protected volatile int overloadTimer;
-    protected volatile Instant overloadReceivedTime;
-    
-    private static final Logger logger = LoggerFactory.getLogger(RateLimiter.class);
-    
-    /**
-     * @param limiters the limits to obey
-     */
-    public RateLimiter(RateLimit... limiters)
-    {
-        limits = Arrays.asList(limiters);
-        
-        firstCallInTime = new HashMap<>();
-        callCountInTime = new HashMap<>();
-        
-        for (RateLimit limit : limits)
-        {
-            firstCallInTime.put(limit, new AtomicLong(Instant.now().toEpochMilli()));
-            callCountInTime.put(limit, new AtomicLong(0));
-        }
-    }
-    
-    @Override
+
+	protected List<RateLimit>            limits;
+	protected Map<RateLimit, AtomicLong> firstCallInTime;
+	protected Map<RateLimit, AtomicLong> callCountInTime;
+
+	protected volatile int overloadTimer;
+	protected volatile Instant overloadReceivedTime;
+
+	protected static final Lock overloadTimerLock = new ReentrantLock();
+
+	private static final Logger logger = LoggerFactory.getLogger(RateLimiter.class);
+
+	/**
+	 * @param limiters the limits to obey
+	 */
+	public RateLimiter(RateLimit... limiters)
+	{
+		limits = Arrays.asList(limiters);
+
+		firstCallInTime = new HashMap<>();
+		callCountInTime = new HashMap<>();
+
+		for (RateLimit limit : limits)
+		{
+			firstCallInTime.put(limit, new AtomicLong(Instant.now().toEpochMilli()));
+			callCountInTime.put(limit, new AtomicLong(0));
+		}
+	}
+
+	@Override
 	public int hashCode() {
 		return Objects.hash(limits);
 	}
@@ -56,100 +59,108 @@ public abstract class RateLimiter
 	}
 
 	public abstract void acquire(Enum platform);
-    
-    public abstract void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platform);
-    
-    public Map<RateLimit, AtomicLong> getFirstCallInTime()
-    {
-        return firstCallInTime;
-    }
-    
-    public Map<RateLimit, AtomicLong> getCallCountInTime()
-    {
-        return callCountInTime;
-    }
-    
-    public List<RateLimit> getLimits()
-    {
-        return limits;
-    }
-    
-    
-    @Override
-    public String toString()
-    {
-        return "RateLimiter{" +
-               "limits=" + limits +
-               ", firstCallInTime=" + firstCallInTime +
-               ", callCountInTime=" + callCountInTime +
-               '}';
-    }
-    
-    public void updateSleep(Instant timeReceived, String sleep, Enum platform)
-    {
-    	DataCallBuilder.getLock(platform).lock();
-        try
-        {
-        	Instant now = Instant.now();
-        	int futurTimer = Integer.parseInt(sleep);
-        	
-        	if(timeReceived.toEpochMilli() + (futurTimer * 1000L) < now.toEpochMilli()) {
-        		logger.debug("Received 429 sleep time {} for platform {}, but the time has already passed (now: {}, received: {})", futurTimer, platform, now, timeReceived);
+
+	public abstract void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platform);
+
+	public Map<RateLimit, AtomicLong> getFirstCallInTime()
+	{
+		return firstCallInTime;
+	}
+
+	public Map<RateLimit, AtomicLong> getCallCountInTime()
+	{
+		return callCountInTime;
+	}
+
+	public List<RateLimit> getLimits()
+	{
+		return limits;
+	}
+
+
+	@Override
+	public String toString()
+	{
+		return "RateLimiter{" +
+				"limits=" + limits +
+				", firstCallInTime=" + firstCallInTime +
+				", callCountInTime=" + callCountInTime +
+				'}';
+	}
+
+	public void updateSleep(Instant timeReceived, String sleep, Enum platform)
+	{
+		overloadTimerLock.lock();
+		try
+		{
+			Instant now = Instant.now();
+			int futurTimer = Integer.parseInt(sleep);
+
+			if(timeReceived.toEpochMilli() + (futurTimer * 1000L) < now.toEpochMilli()) {
+				logger.debug("Received 429 sleep time {} for platform {}, but the time has already passed (now: {}, received: {})", futurTimer, platform, now, timeReceived);
 				return;
-        	}
-        	
-        	resetCalls();
-            overloadTimer = futurTimer;
-            overloadReceivedTime = timeReceived;
-            logger.debug("Forcing next sleep to be atleast: {} seconds (starting at : {})", overloadTimer, timeReceived);
-            
-        } catch (NumberFormatException e)
-        {
-            overloadTimer = 5;
+			}
+
+			// We prioritize the longest sleep time, so that we can avoid being rate limited again
+			if(overloadTimer < futurTimer) { 
+				overloadReceivedTime = timeReceived;
+				overloadTimer = futurTimer;
+				resetCalls();
+			}
+			logger.debug("Forcing next sleep to be atleast: {} seconds (starting at : {})", overloadTimer, timeReceived);
+
+		} catch (NumberFormatException e)
+		{
+			overloadTimer = 5;
 		} finally
 		{
-			DataCallBuilder.getLock(platform).unlock();
+			overloadTimerLock.unlock();
 		}
-    }
-    
-    private void resetCalls()
-    {
-        for (RateLimit limit : limits)
-        {
-            firstCallInTime.get(limit).set(Instant.now().minusMillis(limit.getTimeframeInMS()).toEpochMilli());
-            callCountInTime.get(limit).set(0);
-        }
-    }
-    
-    public void mergeFrom(RateLimiter oldLimit)
-    {
-        if (oldLimit != null)
-        {
-            oldLimit.getCallCountInTime().forEach((key, value) -> {
-                if (callCountInTime.containsKey(key))
-                {
-                    callCountInTime.put(key, value);
-                }
-            });
-            
-            oldLimit.getFirstCallInTime().forEach((key, value) -> {
-                if (firstCallInTime.containsKey(key))
-                {
-                    firstCallInTime.put(key, value);
-                }
-            });
-            
-            this.overloadTimer = oldLimit.overloadTimer;
-        }
-    }
-    
-    public void setCallCountInTime(Map<RateLimit, AtomicLong> callCountInTime)
-    {
-        this.callCountInTime = callCountInTime;
-    }
-    
-    public void setFirstCallInTime(Map<RateLimit, AtomicLong> firstCallInTime)
-    {
-        this.firstCallInTime = firstCallInTime;
-    }
+	}
+
+	private void resetCalls()
+	{
+		overloadTimerLock.lock();
+		try {
+			for (RateLimit limit : limits)
+			{
+				firstCallInTime.get(limit).set(Instant.now().minusMillis(limit.getTimeframeInMS()).toEpochMilli());
+				callCountInTime.get(limit).set(0);
+			}
+		} finally {
+			overloadTimerLock.unlock();
+		}
+	}
+
+	public void mergeFrom(RateLimiter oldLimit)
+	{
+		if (oldLimit != null)
+		{
+			oldLimit.getCallCountInTime().forEach((key, value) -> {
+				if (callCountInTime.containsKey(key))
+				{
+					callCountInTime.put(key, value);
+				}
+			});
+
+			oldLimit.getFirstCallInTime().forEach((key, value) -> {
+				if (firstCallInTime.containsKey(key))
+				{
+					firstCallInTime.put(key, value);
+				}
+			});
+
+			this.overloadTimer = oldLimit.overloadTimer;
+		}
+	}
+
+	public void setCallCountInTime(Map<RateLimit, AtomicLong> callCountInTime)
+	{
+		this.callCountInTime = callCountInTime;
+	}
+
+	public void setFirstCallInTime(Map<RateLimit, AtomicLong> firstCallInTime)
+	{
+		this.firstCallInTime = firstCallInTime;
+	}
 }

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
@@ -54,9 +54,9 @@ public abstract class RateLimiter
 		return Objects.equals(limits, other.limits);
 	}
 
-	public abstract void acquire();
+	public abstract void acquire(Enum platform);
     
-    public abstract void updatePermitsTakenPerX(Map<Integer, Integer> data);
+    public abstract void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platform);
     
     public Map<RateLimit, AtomicLong> getFirstCallInTime()
     {
@@ -84,9 +84,9 @@ public abstract class RateLimiter
                '}';
     }
     
-    public void updateSleep(String sleep)
+    public void updateSleep(String sleep, Enum platform)
     {
-    	DataCallBuilder.lock.lock();
+    	DataCallBuilder.getLock(platform).lock();
         try
         {
         	resetCalls();
@@ -98,7 +98,7 @@ public abstract class RateLimiter
             overloadTimer = 5;
 		} finally
         {
-			DataCallBuilder.lock.unlock();
+			DataCallBuilder.getLock(platform).unlock();
 		}
     }
     

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
@@ -58,9 +58,9 @@ public abstract class RateLimiter
 		return Objects.equals(limits, other.limits);
 	}
 
-	public abstract void acquire(Enum platform);
+	public abstract void acquire(Enum platformOrEndpoint);
 
-	public abstract void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platform);
+	public abstract void updatePermitsTakenPerX(Map<Integer, Integer> data, Enum platformOrEndpoint);
 
 	public Map<RateLimit, AtomicLong> getFirstCallInTime()
 	{

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
@@ -135,7 +135,8 @@ public abstract class RateLimiter
 		if (oldLimit != null)
 		{
 			
-			if(oldLimit instanceof CounterRateLimiter toConvert) {
+			if(oldLimit instanceof CounterRateLimiter) {
+				CounterRateLimiter toConvert = (CounterRateLimiter) oldLimit;
 				for(RateLimit limit : limits) {
 					firstCallInTime.put(limit, oldLimit.getFirstCallInTime().get(toConvert.getDummyLimit()));
 					callCountInTime.put(limit, oldLimit.getCallCountInTime().get(toConvert.getDummyLimit()));

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
@@ -2,6 +2,8 @@ package no.stelar7.api.r4j.basic.ratelimiting;
 
 import org.slf4j.*;
 
+import no.stelar7.api.r4j.basic.calling.DataCallBuilder;
+
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -13,9 +15,7 @@ public abstract class RateLimiter
     protected List<RateLimit>            limits;
     protected Map<RateLimit, AtomicLong> firstCallInTime;
     protected Map<RateLimit, AtomicLong> callCountInTime;
-    
-    protected ReentrantLock lock = new ReentrantLock();
-    
+        
     protected volatile int overloadTimer;
     
     private static final Logger logger = LoggerFactory.getLogger(RateLimiter.class);
@@ -86,7 +86,7 @@ public abstract class RateLimiter
     
     public void updateSleep(String sleep)
     {
-    	lock.lock();
+    	DataCallBuilder.lock.lock();
         try
         {
         	resetCalls();
@@ -98,7 +98,7 @@ public abstract class RateLimiter
             overloadTimer = 5;
 		} finally
         {
-			lock.unlock();
+			DataCallBuilder.lock.unlock();
 		}
     }
     


### PR DESCRIPTION
Big update solving rate limiter problems. I've fixed multiple problems affecting the rate limiter, including:

- The rate limiter was not correctly handling several different keys (League, TFT used at the same time for example)
- Multiple race conditions in multiple places.
- Almost complete rewrite of the BurstRateLimter class to better handle complex cases. I got the impression that the code was primarily designed for synchronous code and that this was the source of many problems.

This fix isn't perfect and I still see the following problems:
- If a request is possible for the "user limit" but a ‘method’ limit is reached and the thread has to wait, the request is incorrectly counted in the “user” rate limit.
- There are formatting problems, I'd like to fix this before merge.
- there are still multiple security thresholds that don't allow the full potential of a key to be exploited. It should be removed eventually if possible.
- A hard-coded semaphore currently allows a maximum of 200 requests at a time, a threshold should be added for the user.

The situation is much better and the 429 is no longer reached in a context with a lot of parallelized requests.

Side note: brawl game queue id added too in this PR.