### PR TITLE
Help Needed - add new found queue id

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
@@ -414,6 +414,14 @@ public enum GameQueueType implements CodedEnum
     SWIFTPLAY(480),
 
     DOOMBOTS_V2(4210, 4220, 4240, 4250, 4260),
+    
+    PRACTICE_TOOL(3140),
+    
+    // FIXME : Figure out what these queues really are
+    // I'm absolutely not sure about the true meaning of the 3110, 3120, 3130 codes, but they seem to be some kind of custom games ? (Even if marked as "Matched"???)
+    CUSTOM_SUMMONERS_RIFT(3100, 3110, 3120, 3130), 
+    // I'm absolutely not sure about the true meaning of the 3210, 3220 and 3230 codes either
+    CUSTOM_ARAM(3200, 3210, 3220, 3230),
     ;
     
     private final Integer[] codes;


### PR DESCRIPTION
Hello,

I noticed a lot of new id (for league game match) that i never seen before. Some of them are related to the practice tool (3140), some to custom game (3100 summoner rift, 3200 aram). 

But i have some i have absolutely no idea like 3110 ??? It's apparently a matched game so not a custom but then what could it be then ? Maybe a kind of custom game (with some kind of settings) that get miss labeled as matched ?

These id are not found inside https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/queues.json

If needed, i can give some match id example i have found.