### PR TITLE
Fix (again) SEA shard

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/api/regions/LeagueShard.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/api/regions/LeagueShard.java
@@ -206,6 +206,42 @@ public enum LeagueShard implements CodedEnum, RealmSpesificEnum
                 return RegionShard.EUROPE;
             case JP1:
             case KR:
+                return RegionShard.ASIA;
+            case ID1:
+            case SG2:
+            case PH2:
+            case VN2:
+            case TH2:
+            case TW2:
+            case OC1:
+                return RegionShard.SEA;
+            case PBE1:
+                return RegionShard.PBE;
+            default:
+                throw new APIEnumNotUpToDateException(RegionShard.class, new JsonPrimitive(this.toString()));
+        }
+    }
+
+    public RegionShard toAccountRegionShard()
+    {
+        switch (this)
+        {
+            
+            case UNKNOWN:
+                return RegionShard.UNKNOWN;
+            case BR1:
+            case NA1:
+            case LA1:
+            case LA2:
+                return RegionShard.AMERICAS;
+            case EUN1:
+            case EUW1:
+            case TR1:
+            case RU:
+            case ME1:
+                return RegionShard.EUROPE;
+            case JP1:
+            case KR:
             case ID1:
             case SG2:
             case PH2:


### PR DESCRIPTION
About the PR [#124](https://github.com/stelar7/R4J/pull/124)
I found a bug

Reading the account-v1 api docs:
> There are three routing values for account-v1; americas, asia, and europe. You can query for any account in any region. We recommend using the nearest cluster.

While Match/Matchlist V5
> The AMERICAS routing value serves NA, BR, LAN and LAS. The ASIA routing value serves KR and JP. The EUROPE routing value serves EUNE, EUW, ME1, TR and RU. The SEA routing value serves OCE, SG2, TW2 and VN2.

so, my fix TW2.toRegionShard() -> ASIA made the account v1 works but broke the Matchlist, since now it needs the SEA shard

i dont know if its better to create two different toRegionShard -> toAccountRegionShard(), toRegionShard() and replace the references around the code.
Anyway reverting the commit would made the matchlist works again and you can use the other method for the accountV1

`r4j.getAccountAPI().getAccountByPUUID(leagueShard.toAccountRegionShard(), puuid)`