### PR TITLE
Add missing queue type for Arena

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/constants/types/lol/GameQueueType.java
@@ -371,8 +371,9 @@ public enum GameQueueType implements CodedEnum
     /**
      * 2v2v2v2 (Arena)
      * 1750: Cherry 3v3v3v3
+     * 1740: Not sure about it
      */
-    CHERRY(1700, 1701, 1704, 1710, 1750),
+    CHERRY(1700, 1701, 1704, 1710, 1740, 1750),
     
     /**
      * 5v5 Brawl


### PR DESCRIPTION
Guess according to the id naming logic + the "CHERRY" identification in the server answer, but i didn't find any more info about why this is a different id (it's still a 3vs3vs3vs...).

Example of game id : EUW1_7922317765