### PR TITLE
Handle undocumented 'server' X-Rate-Limit-Type and honor correctly service rate limits

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCall.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCall.java
@@ -27,6 +27,7 @@ public final class DataCall
     private static int            callStackLimit = 5;
     private static long           maxSleep       = 10000;
     private static int            globalTimeout  = 0;
+    private static boolean        failFastOnServiceRatelimit = false;
     
     private final Map<String, String> urlParams  = new LinkedHashMap<>();
     private final Map<String, String> urlData    = new LinkedHashMap<>();
@@ -275,6 +276,21 @@ public final class DataCall
     public static void setGlobalTimeout(int globalTimeout)
     {
         DataCall.globalTimeout = globalTimeout;
+    }
+
+    public static boolean shouldFailFastOnServiceRatelimit()
+    {
+        return failFastOnServiceRatelimit;
+    }
+
+    /**
+     * A service rate limit can sometimes be hit (limits that are not linked to your API key, but to the Riot server itself),
+     * this flag determines whether this type of rate limit should fail immediately (throwing an APIEndpointCooldownException) or sleep until the cooldown expires.
+     * Can be useful for high-throughput applications who prefer to fail fast so they can do other not limited calls instead of waiting for the cooldown to expire.
+     */
+    public static void setFailFastOnServiceRatelimit(boolean failFastOnServiceRatelimit)
+    {
+        DataCall.failFastOnServiceRatelimit = failFastOnServiceRatelimit;
     }
     
     public boolean shouldReturnRawResponse()

--- a/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/calling/DataCallBuilder.java
@@ -630,9 +630,9 @@ public class DataCallBuilder
                 
                 logger.warn("Ratelimit hit for platform: {}, endpoint: {}, method: {}, app limit: {}/{}, method limit: {}/{}",
                         this.dc.getPlatform(), this.dc.getEndpoint(), this.requestMethod, appB, appA, methodB, methodA);
-                
+
                 final RateLimitType limitType = RateLimitType.getBestMatch(con.getHeaderField("X-Rate-Limit-Type"));
-                
+
                 if (limitType == RateLimitType.LIMIT_METHOD)
                 {
                     RateLimiter limter = DataCall.getLimiter(dc.getKeyUsedByHeadersUsed()).get(this.dc.getPlatform()).get(this.dc.getEndpoint());
@@ -641,9 +641,19 @@ public class DataCallBuilder
                 
                 if (limitType == RateLimitType.LIMIT_USER)
                 {
-                    
+
                     RateLimiter limter = DataCall.getLimiter(dc.getKeyUsedByHeadersUsed()).get(this.dc.getPlatform()).get(this.dc.getPlatform());
                     limter.updateSleep(received, con.getHeaderField("Retry-After"), this.dc.getPlatform());
+                }
+
+                if (limitType == RateLimitType.LIMIT_UNDERLYING || limitType == RateLimitType.LIMIT_SERVICE)
+                {
+                    Map<Enum, RateLimiter> platformLimiters = DataCall.getLimiter(dc.getKeyUsedByHeadersUsed()).get(this.dc.getPlatform());
+                    RateLimiter limter = platformLimiters == null ? null : platformLimiters.get(this.dc.getEndpoint());
+                    if (limter != null)
+                    {
+                        limter.updateSleep(received, con.getHeaderField("Retry-After"), this.dc.getPlatform(), DataCall.shouldFailFastOnServiceRatelimit());
+                    }
                 }
             }
             

--- a/src/main/java/no/stelar7/api/r4j/basic/exceptions/APIEndpointCooldownException.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/exceptions/APIEndpointCooldownException.java
@@ -1,0 +1,24 @@
+package no.stelar7.api.r4j.basic.exceptions;
+
+/**
+ * Thrown before any HTTP call is made when the target endpoint is in a server-side
+ * ratelimit cooldown (not linked to the API Key rate limit, rate limit on the Riot server itself) 
+ * and that the "DataCall.setFailFastOnServiceRatelimit()" flag is true.
+ * 
+ * Callers may treat this as "data unavailable right now" and retry later.
+ */
+public class APIEndpointCooldownException extends RuntimeException
+{
+    private final long remainingCooldownMs;
+
+    public APIEndpointCooldownException(String endpointName, long remainingCooldownMs)
+    {
+        super("Endpoint " + endpointName + " is in a server-side ratelimit cooldown for another " + remainingCooldownMs + " ms");
+        this.remainingCooldownMs = remainingCooldownMs;
+    }
+
+    public long getRemainingCooldownMs()
+    {
+        return remainingCooldownMs;
+    }
+}

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/BurstRateLimiter.java
@@ -3,6 +3,7 @@ package no.stelar7.api.r4j.basic.ratelimiting;
 
 import no.stelar7.api.r4j.basic.calling.DataCallBuilder;
 import no.stelar7.api.r4j.basic.constants.types.ApiKeyType;
+import no.stelar7.api.r4j.basic.exceptions.APIEndpointCooldownException;
 
 import org.slf4j.*;
 
@@ -50,8 +51,14 @@ public class BurstRateLimiter extends RateLimiter
                 if (realtimeToWait <= 0) {
                     logger.debug("Overload timer reset for {} since time overpassed", platformOrEndpoint.name());
                     overloadTimer = 0; // Reset overload timer after waiting
+                    overloadFailFast = false;
                     resetCalls(); // Reset the call counts since we are no longer in an overload state
                     return; // Overload timer has passed, no need to wait
+                } else if (overloadFailFast) {
+                    // Service-limit cooldown in fail-fast mode: blocking here would hold the caller
+                    // thread (and its parallel-call permit) for the whole cooldown. Fail immediately
+                    // instead, without making the HTTP call.
+                    throw new APIEndpointCooldownException(platformOrEndpoint.name(), realtimeToWait);
                 } else {
                     logger.debug("Overload timer still active for {}. Waiting {} ms", platformOrEndpoint.name(), realtimeToWait);
                     msToWait = realtimeToWait;

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimitType.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimitType.java
@@ -1,6 +1,7 @@
 package no.stelar7.api.r4j.basic.ratelimiting;
 
-import no.stelar7.api.r4j.basic.exceptions.APIDataNotParseableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.stream.Stream;
 
@@ -20,13 +21,18 @@ public enum RateLimitType
         this.reason = reason;
     }
     
+    private static final Logger logger = LoggerFactory.getLogger(RateLimitType.class);
+
     public static RateLimitType getBestMatch(String data)
     {
         if (data == null)
         {
             return LIMIT_UNDERLYING;
         }
-        return Stream.of(values()).filter(s -> s.getValue().equalsIgnoreCase(data)).findFirst().orElseThrow(() -> new APIDataNotParseableException(data));
+        return Stream.of(values()).filter(s -> s.getValue().equalsIgnoreCase(data)).findFirst().orElseGet(() -> {
+            logger.warn("Unknown X-Rate-Limit-Type header value '{}', treating it as an underlying service limit", data);
+            return LIMIT_UNDERLYING;
+        });
     }
     
     public String getValue()

--- a/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
+++ b/src/main/java/no/stelar7/api/r4j/basic/ratelimiting/RateLimiter.java
@@ -20,6 +20,7 @@ public abstract class RateLimiter
     
     protected volatile int overloadTimer;
     protected volatile Instant overloadReceivedTime;
+    protected volatile boolean overloadFailFast;
     
     protected static final Lock overloadTimerLock = new ReentrantLock();
     
@@ -101,29 +102,40 @@ public abstract class RateLimiter
     
     public void updateSleep(Instant timeReceived, String sleep, Enum platform)
     {
+        updateSleep(timeReceived, sleep, platform, false);
+    }
+
+    /**
+     * @param failFast when true, calls arriving while this cooldown is active fail immediately
+     *                 with an APIEndpointCooldownException instead of sleeping it out.
+     */
+    public void updateSleep(Instant timeReceived, String sleep, Enum platform, boolean failFast)
+    {
         Instant now = Instant.now();
         overloadTimerLock.lock();
         try
         {
             int futurTimer = Integer.parseInt(sleep);
-            
+
             if(timeReceived.toEpochMilli() + (futurTimer * 1000L) < now.toEpochMilli()) {
                 logger.debug("Received 429 sleep time {} for platform {}, but the time has already passed (now: {}, received: {})", futurTimer, platform, now, timeReceived);
                 return;
             }
-            
+
             // We prioritize the most recent sleep time
-            if(overloadReceivedTime.toEpochMilli() < timeReceived.toEpochMilli()) { 
+            if(overloadReceivedTime.toEpochMilli() < timeReceived.toEpochMilli()) {
                 overloadReceivedTime = timeReceived;
                 overloadTimer = futurTimer;
+                overloadFailFast = failFast;
                 //resetCalls(); We should reset calls only after the sleep has been applied
             }
             logger.debug("Forcing next sleep to be atleast: {} seconds (starting at : {})", overloadTimer, timeReceived);
-            
+
         } catch (NumberFormatException e)
         {
             overloadTimer = 5;
             overloadReceivedTime = now;
+            overloadFailFast = failFast;
         } finally
         {
             overloadTimerLock.unlock();
@@ -154,6 +166,7 @@ public abstract class RateLimiter
                 
                 this.overloadTimer = oldLimit.overloadTimer;
                 this.overloadReceivedTime = oldLimit.overloadReceivedTime;
+                this.overloadFailFast = oldLimit.overloadFailFast;
                 return;
             }
             
@@ -173,6 +186,7 @@ public abstract class RateLimiter
             
             this.overloadTimer = oldLimit.overloadTimer;
             this.overloadReceivedTime = oldLimit.overloadReceivedTime;
+            this.overloadFailFast = oldLimit.overloadFailFast;
         }
     }
     


### PR DESCRIPTION
Riot's spectator-v5 endpoint (and probably others endpoints too) can return 429s with an undocumented `X-Rate-Limit-Type: server` header (body: `"server rate limit exceeded"`, always with a `Retry-After` of 5–21 s, no app/method rate limit headers). Two problems with how R4J handles this today:

- `RateLimitType.getBestMatch` throws `APIDataNotParseableException` on any unknown header value, so the call dies with a parse error instead of a ratelimit signal.
- Even for known service-typed 429s, `Retry-After` is ignored and the call is retried immediately, hammering an already overloaded Riot service.

**Fix:**

- Unknown `X-Rate-Limit-Type` values now log a WARN and fall back to `LIMIT_UNDERLYING` instead of throwing an exception.
- Service-typed 429s now arm a `Retry-After` cooldown on the affected endpoint's limiter (scoped per endpoint per platform), so nothing is sent to that endpoint until the cooldown expires. Same mechanism method/app limits already use.

**New opt-in setting:** by default, a call made during such a cooldown sleeps until it expires (consistent with the other limit types). With `DataCall.setFailFastOnServiceRatelimit(true)`, it instead throws the new `APIEndpointCooldownException` immediately, before any HTTP call. Can be useful in some use case.