### PR TITLE
Add support for augment 5 & 6

### DIFF
--- a/src/main/java/no/stelar7/api/r4j/pojo/lol/match/v5/MatchParticipant.java
+++ b/src/main/java/no/stelar7/api/r4j/pojo/lol/match/v5/MatchParticipant.java
@@ -87,6 +87,8 @@ public class MatchParticipant implements Serializable
     private int                 playerAugment2;
     private int                 playerAugment3;
     private int                 playerAugment4;
+    private int                 playerAugment5;
+    private int                 playerAugment6;
     private int                 playerSubteamId;
     private int                 profileIcon;
     private int                 pushPings;
@@ -530,6 +532,16 @@ public class MatchParticipant implements Serializable
     {
         return playerAugment4;
     }
+
+    public int getPlayerAugment5()
+    {
+        return playerAugment5;
+    }
+
+    public int getPlayerAugment6()
+    {
+        return playerAugment6;
+    }
     
     public int getPlayerSubteamId()
     {
@@ -881,6 +893,8 @@ public class MatchParticipant implements Serializable
                && playerAugment2 == that.playerAugment2
                && playerAugment3 == that.playerAugment3
                && playerAugment4 == that.playerAugment4
+               && playerAugment5 == that.playerAugment5
+               && playerAugment6 == that.playerAugment6
                && playerSubteamId == that.playerSubteamId
                && profileIcon == that.profileIcon
                && pushPings == that.pushPings
@@ -1022,6 +1036,8 @@ public class MatchParticipant implements Serializable
                             playerAugment2,
                             playerAugment3,
                             playerAugment4,
+                            playerAugment5,
+                            playerAugment6,
                             playerSubteamId,
                             profileIcon,
                             pushPings,
@@ -1159,6 +1175,8 @@ public class MatchParticipant implements Serializable
                ", playerAugment2=" + playerAugment2 +
                ", playerAugment3=" + playerAugment3 +
                ", playerAugment4=" + playerAugment4 +
+               ", playerAugment5=" + playerAugment5 +
+               ", playerAugment6=" + playerAugment6 +
                ", playerSubteamId=" + playerSubteamId +
                ", profileIcon=" + profileIcon +
                ", pushPings=" + pushPings +

--- a/src/test/java/no/stelar7/api/r4j/tests/lol/match/MatchListV5Test.java
+++ b/src/test/java/no/stelar7/api/r4j/tests/lol/match/MatchListV5Test.java
@@ -5,6 +5,7 @@ import com.google.gson.stream.JsonWriter;
 import no.stelar7.api.r4j.basic.cache.impl.FileSystemCacheProvider;
 import no.stelar7.api.r4j.basic.calling.DataCall;
 import no.stelar7.api.r4j.basic.constants.api.regions.LeagueShard;
+import no.stelar7.api.r4j.basic.constants.api.regions.RegionShard;
 import no.stelar7.api.r4j.basic.constants.types.lol.*;
 import no.stelar7.api.r4j.basic.utils.*;
 import no.stelar7.api.r4j.impl.R4J;
@@ -189,6 +190,49 @@ public class MatchListV5Test
     {
         LOLMatch match = LOLMatch.get(LeagueShard.BR1, "BR1_2344333561");
         System.out.println();
+    }
+    
+    @Test
+    public void testMatch6Augments()
+    {
+        RiotAccount riotAccount = r4J.getAccountAPI().getAccountByTag(RegionShard.AMERICAS, "yuuuda", "NA1");
+
+        List<String> matchsids = r4J.getLoLAPI().getMatchAPI().getMatchList(RegionShard.AMERICAS, riotAccount.getPUUID(), null, null, 0, 20, null, null);
+        
+        boolean foundSixAugments = false;
+        for (String matchId : matchsids)
+        {
+            LOLMatch match = LOLMatch.get(LeagueShard.NA1, matchId);
+            if (match.getQueue() != GameQueueType.CHERRY)
+            {
+                continue;
+            }
+
+            for (MatchParticipant participant : match.getParticipants())
+            {
+                int[] slots = {
+                    participant.getPlayerAugment1(), participant.getPlayerAugment2(), participant.getPlayerAugment3(),
+                    participant.getPlayerAugment4(), participant.getPlayerAugment5(), participant.getPlayerAugment6(),
+                };
+                List<Integer> augments = new ArrayList<>();
+                for (int slot : slots)
+                {
+                    if (slot != 0)
+                    {
+                        augments.add(slot);
+                    }
+                }
+
+                System.out.println(matchId + " " + participant.getRiotIdName() + "#" + participant.getRiotIdTagline() + " -> " + augments);
+
+                if (augments.size() == 6)
+                {
+                    foundSixAugments = true;
+                }
+            }
+        }
+
+        Assertions.assertTrue(foundSixAugments, "expected at least one Arena participant with 6 augments in the last 20 games");
     }
     
     @Test


### PR DESCRIPTION
Not documented by Riot, but theses two fields are served by the MATCH-V5 api endpoint. I added a test that verify that they exist.